### PR TITLE
Fix dynamic code execution in safe mode

### DIFF
--- a/src/njs_function.c
+++ b/src/njs_function.c
@@ -898,6 +898,7 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
          */
 
         if (str.length != njs_length("return this")
+            || nargs != 1
             || memcmp(str.start, "return this", 11) != 0)
         {
             njs_type_error(vm, "function constructor is disabled"

--- a/test/njs_expect_test.exp
+++ b/test/njs_expect_test.exp
@@ -808,6 +808,8 @@ njs_test {
      "TypeError: function constructor is disabled in \"safe\" mode\r\n"}
     {"new Function('return thi')\r\n"
      "TypeError: function constructor is disabled in \"safe\" mode\r\n"}
+    {"new Function('foo','return this')\r\n"
+     "TypeError: function constructor is disabled in \"safe\" mode\r\n"}
 } "-u"
 
 


### PR DESCRIPTION
Hi. I found a "Function" workaround and now in safe mode we can execute dynamic code like as "eval". 
I think it is security vuln and need CVE?

```
Function("){return 1337})//", "return this")();
```
BTW Why function arguments are not sanitized? It just concatenate string.