### PR TITLE
Always use a sharp (#) symbol as a sed(1) separator.

### DIFF
--- a/auto/libxml2
+++ b/auto/libxml2
@@ -26,7 +26,7 @@ if [ $NJS_LIBXML2 = YES ]; then
         # pkg-config
 
         njs_feature="libxml2 via pkg-config"
-        njs_feature_incs=`pkg-config libxml-2.0 --cflags | sed -n -e 's/.*-I *\([^ ][^ ]*\).*/\1/p'`
+        njs_feature_incs=`pkg-config libxml-2.0 --cflags | sed -n -e 's#.*-I *\([^ ][^ ]*\).*#\1#p'`
         njs_feature_libs=`pkg-config libxml-2.0 --libs`
 
         . auto/feature

--- a/auto/make
+++ b/auto/make
@@ -54,7 +54,7 @@ NJS_STATIC_LINK = ${AR} -r -c
 NJS_LINK = ${CC} ${NJS_LD_OPT}
 NJS_CFLAGS = ${NJS_CFLAGS} ${NJS_CC_OPT} ${CFLAGS}
 
-NJS_VER = $(grep NJS_VERSION src/njs.h | sed -e 's/.*"\(.*\)".*/\1/')
+NJS_VER = $(grep NJS_VERSION src/njs.h | sed -e 's#.*"\(.*\)".*#\1#')
 NJS_TYPES_VER = \$(NJS_VER)
 
 NPM = npm
@@ -275,7 +275,7 @@ cat << END >> $NJS_MAKEFILE
 $NJS_BUILD_DIR/ts/package.json: $njs_ts_deps
 	cp -fr ts $NJS_BUILD_DIR/
 	cp LICENSE $NJS_BUILD_DIR/ts/
-	sed 's/__VERSION__/"\$(NJS_TYPES_VER)"/' \\
+	sed 's#__VERSION__#"\$(NJS_TYPES_VER)"#' \\
 		ts/package.json > $NJS_BUILD_DIR/ts/package.json
 
 $NJS_BUILD_DIR/ts/node_modules: $NJS_BUILD_DIR/ts/package.json
@@ -320,11 +320,11 @@ cat << END >> $NJS_MAKEFILE
 pc: $NJS_BUILD_DIR/njs.pc
 
 $NJS_BUILD_DIR/njs.pc: $NJS_BUILD_DIR/njs_auto_config.h
-	sed -e "s,@PREFIX@,$(pwd)/$NJS_BUILD_DIR," \\
-		-e "s,@LIBDIR@,$(pwd)/$NJS_BUILD_DIR," \\
-		-e "s,@CFLAGS@,-I$(pwd)/$NJS_BUILD_DIR -I$(pwd)/src," \\
-		-e "s,@VERSION@,\$(NJS_VER)," \\
-		-e "s,@EXTRA_LIBS@,-lm $NJS_LIBS $NJS_LIB_AUX_LIBS," \\
+	sed -e "s#@PREFIX@#$(pwd)/$NJS_BUILD_DIR#" \\
+		-e "s#@LIBDIR@#$(pwd)/$NJS_BUILD_DIR#" \\
+		-e "s#@CFLAGS@#-I$(pwd)/$NJS_BUILD_DIR -I$(pwd)/src#" \\
+		-e "s#@VERSION@#\$(NJS_VER)#" \\
+		-e "s#@EXTRA_LIBS@#-lm $NJS_LIBS $NJS_LIB_AUX_LIBS#" \\
 		src/njs.pc.in > \$@
 END
 

--- a/auto/options
+++ b/auto/options
@@ -28,7 +28,7 @@ NJS_CONFIGURE_OPTIONS=
 for njs_option
 do
     case "$njs_option" in
-        -*=*) value=`echo "$njs_option" | sed -e 's/[-_a-zA-Z0-9]*=//'`      ;;
+        -*=*) value=`echo "$njs_option" | sed -e 's#[-_a-zA-Z0-9]*=##'`      ;;
            *) value="" ;;
     esac
 
@@ -70,7 +70,7 @@ do
         ;;
     esac
 
-    njs_opt=`echo $njs_option | sed -e "s/\(--[^=]*=\)\(.* .*\)/\1'\2'/"`
+    njs_opt=`echo $njs_option | sed -e "s#\(--[^=]*=\)\(.* .*\)#\1'\2'#"`
 
     NJS_CONFIGURE_OPTIONS="$NJS_CONFIGURE_OPTIONS $njs_opt"
 

--- a/auto/zlib
+++ b/auto/zlib
@@ -26,7 +26,7 @@ if [ $NJS_ZLIB = YES ]; then
         # pkg-config
 
         njs_feature="zlib via pkg-config"
-        njs_feature_incs=`pkg-config zlib --cflags | sed -n -e 's/.*-I *\([^ ][^ ]*\).*/\1/p'`
+        njs_feature_incs=`pkg-config zlib --cflags | sed -n -e 's#.*-I *\([^ ][^ ]*\).*#\1#p'`
         njs_feature_libs=`pkg-config zlib --libs`
 
         . auto/feature


### PR DESCRIPTION
sed(1) command line utility may fail with the following error:
sed: 1: "s, at EXTRA_LIBS@,-lm   -L ...": bad in substitute command: '-'
when a replacement for @EXTRA_LIBS@ contains a comma symbol.