### PR TITLE
random: prioritise CCRandomGenerateBytes over getentropy on macOs.

### DIFF
--- a/auto/getrandom
+++ b/auto/getrandom
@@ -50,6 +50,27 @@ fi
 
 if [ $njs_found = no ]; then
 
+    # macOS 10.10.
+
+    njs_feature="CCRandomGenerateBytes() in CommonCrypto/CommonRandom.h"
+    njs_feature_name=NJS_HAVE_CCRANDOMGENERATEBYTES
+    njs_feature_test="#include <CommonCrypto/CommonCryptoError.h>
+                      #include <CommonCrypto/CommonRandom.h>
+
+                      int main(void) {
+                          char  buf[4];
+
+                          if (CCRandomGenerateBytes(buf, 4) != kCCSuccess) {
+                              return 1;
+                          }
+
+                          return 0;
+                      }"
+    . auto/feature
+fi
+
+if [ $njs_found = no ]; then
+
     # OpenBSD 5.6 lacks <sys/random.h>.
 
     njs_feature="getentropy()"
@@ -68,10 +89,9 @@ if [ $njs_found = no ]; then
     . auto/feature
 fi
 
-
 if [ $njs_found = no ]; then
 
-    # macOS 10.12.
+    # Solaris based systems.
 
     njs_feature="getentropy() in sys/random.h"
     njs_feature_name=NJS_HAVE_GETENTROPY_SYS_RANDOM

--- a/src/njs_random.c
+++ b/src/njs_random.c
@@ -8,6 +8,9 @@
 #include <njs_main.h>
 #if (NJS_HAVE_GETRANDOM)
 #include <sys/random.h>
+#elif (NJS_HAVE_CCRANDOMGENERATEBYTES)
+#include <CommonCrypto/CommonCryptoError.h>
+#include <CommonCrypto/CommonRandom.h>
 #elif (NJS_HAVE_LINUX_SYS_GETRANDOM)
 #include <sys/syscall.h>
 #include <linux/random.h>
@@ -71,6 +74,16 @@ njs_random_stir(njs_random_t *r, njs_pid_t pid)
     /* Linux 3.17 SYS_getrandom, not available in Glibc prior to 2.25. */
 
     n = syscall(SYS_getrandom, &key, NJS_RANDOM_KEY_SIZE, 0);
+
+#elif (NJS_HAVE_CCRANDOMGENERATEBYTES)
+
+    /* Apple discourages the use of getentropy, to the point it's even forbidden on the Apple's App Store. */
+
+    n = 0;
+
+    if (CCRandomGenerateBytes(&key, NJS_RANDOM_KEY_SIZE) == kCCSuccess) {
+        n = NJS_RANDOM_KEY_SIZE;
+    }
 
 #elif (NJS_HAVE_GETENTROPY || NJS_HAVE_GETENTROPY_SYS_RANDOM)
 


### PR DESCRIPTION
recommended approach by Apple itself.
e.g. https://github.com/openssl/openssl/commit/f0b9e75e4f9d6ae74389cd1b019b77cf2bd01033