### PR TITLE
Test262: improved skipping of tests.

### DIFF
--- a/test/test262
+++ b/test/test262
@@ -19,6 +19,11 @@ for njs_test in $NJS_TESTS; do
 running $njs_test $njs_log
 END
 
+    if [ "$NJS_SKIP_LIST" != "${NJS_SKIP_LIST#*$njs_test*}" ]; then
+        skip $njs_test
+        continue
+    fi
+
     status=0
 
     NJS_PATH=$njs_paths \
@@ -27,11 +32,6 @@ END
 
     cat $njs_log >> $NJS_TEST_LOG
     njs_out=`cat $njs_log`
-
-    if [ "$NJS_SKIP_LIST" != "${NJS_SKIP_LIST#*$njs_test*}" ]; then
-        skip $njs_test
-        continue
-    fi
 
     if [ "$status" -eq 0 ]; then
         if [ -n "$njs_negative" ]; then


### PR DESCRIPTION
The skipped tests (which are expected to fail) are not executed in order to make output clearer.