### PR TITLE
Fixed open byte overread in decodeURI() and decodeURIComponent().

### DIFF
--- a/src/njs_string.c
+++ b/src/njs_string.c
@@ -4074,7 +4074,7 @@ njs_string_decode_uri(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
             n++;
         } while (((cp << n) & 0x80));
 
-        if (njs_slow_path(n > 4)) {
+        if (njs_slow_path(n > 4 || src + njs_length("%00") * (n - 1)  > end)) {
             goto uri_error;
         }
 

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -10016,13 +10016,17 @@ static njs_unit_test_t  njs_test[] =
               " '%',"
               " '%0',"
               " '%QQ',"
+              " '%C0%' + '0',"
               " '%C0%10',"
+              " '%C0%80',"
               " '%DC%C7',"
               " '%80%81%82',"
               " '%EF%5C%A0',"
               " '%EF%A0%5E',"
+              " '%E0%EF%' + '0',"
               " '%E0%EF%A0',"
               " '%E0%A0%EF',"
+              " '%F0%A2%95%' + '0',"
               " '%FF%A2%95%BB',"
               "].every(v=>{try { decodeURI(v)} catch(e) {return e.name == 'URIError'}})"),
       njs_str("true")},


### PR DESCRIPTION
Found by OSS-Fuzz and MemorySanitizer.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
