### PR TITLE
Fixed ‘length’ may be used in Array.prototype.pop().

### DIFF
--- a/src/njs_utf8.h
+++ b/src/njs_utf8.h
@@ -128,6 +128,7 @@ njs_utf8_decode_init(njs_unicode_decode_t *ctx)
 {
     ctx->need = 0x00;
     ctx->lower = 0x00;
+    ctx->codepoint = 0;
 }
 
 

--- a/src/njs_value_conversion.h
+++ b/src/njs_value_conversion.h
@@ -17,7 +17,7 @@ njs_value_to_number(njs_vm_t *vm, njs_value_t *value, double *dst)
     if (njs_slow_path(!njs_is_primitive(value))) {
         ret = njs_value_to_primitive(vm, &primitive, value, 0);
         if (njs_slow_path(ret != NJS_OK)) {
-            return ret;
+            return NJS_ERROR;
         }
 
         value = &primitive;


### PR DESCRIPTION
When building by GCC with -O3 and -flto flags the following warning was reported:
src/njs_array.c: In function ‘njs_array_prototype_pop’: src/njs_array.c:1009:8: error: ‘length’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
1009 | if (length == 0) {
     |     ^

Returning a specific code in njs_value_to_number() helps GCC to infer that there are only 2 return values are possible and both of them are handled.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
