### PR TITLE
Fixed maybe-uninitialized warning in error creation.

### DIFF
--- a/src/njs_error.c
+++ b/src/njs_error.c
@@ -60,11 +60,7 @@ njs_throw_error_va(njs_vm_t *vm, njs_object_t *proto, const char *fmt,
 {
     u_char   buf[NJS_MAX_ERROR_STR], *p;
 
-    p = buf;
-
-    if (fmt != NULL) {
-        p = njs_vsprintf(buf, buf + sizeof(buf), fmt, args);
-    }
+    p = njs_vsprintf(buf, buf + sizeof(buf), fmt, args);
 
     njs_error_new(vm, &vm->exception, proto, buf, p - buf);
 }
@@ -88,13 +84,9 @@ njs_error_fmt_new(njs_vm_t *vm, njs_value_t *dst, njs_object_type_t type,
     va_list  args;
     u_char   buf[NJS_MAX_ERROR_STR], *p;
 
-    p = buf;
-
-    if (fmt != NULL) {
-        va_start(args, fmt);
-        p = njs_vsprintf(buf, buf + sizeof(buf), fmt, args);
-        va_end(args);
-    }
+    va_start(args, fmt);
+    p = njs_vsprintf(buf, buf + sizeof(buf), fmt, args);
+    va_end(args);
 
     njs_error_new(vm, dst, njs_vm_proto(vm, type), buf, p - buf);
 }

--- a/src/njs_number.c
+++ b/src/njs_number.c
@@ -543,7 +543,7 @@ njs_number_prototype_to_string(njs_vm_t *vm, njs_value_t *args,
         }
 
         if (radix < 2 || radix > 36 || radix != (int) radix) {
-            njs_range_error(vm, NULL);
+            njs_range_error(vm, "radix argument must be between 2 and 36");
             return NJS_ERROR;
         }
 

--- a/src/njs_string.c
+++ b/src/njs_string.c
@@ -1695,7 +1695,7 @@ njs_string_from_char_code(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
 range_error:
 
-    njs_range_error(vm, NULL);
+    njs_range_error(vm, "invalid code point");
 
     return NJS_ERROR;
 }
@@ -2503,7 +2503,7 @@ njs_string_prototype_repeat(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (njs_slow_path(n < 0 || n == INT64_MAX)) {
-        njs_range_error(vm, NULL);
+        njs_range_error(vm, "invalid count value");
         return NJS_ERROR;
     }
 
@@ -2517,7 +2517,7 @@ njs_string_prototype_repeat(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     max = NJS_STRING_MAX_LENGTH / string.size;
 
     if (njs_slow_path(n >= max)) {
-        njs_range_error(vm, NULL);
+        njs_range_error(vm, "invalid string length");
         return NJS_ERROR;
     }
 
@@ -2583,7 +2583,7 @@ njs_string_prototype_pad(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (njs_slow_path(new_length >= NJS_STRING_MAX_LENGTH)) {
-        njs_range_error(vm, NULL);
+        njs_range_error(vm, "invalid string length");
         return NJS_ERROR;
     }
 

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -630,13 +630,13 @@ static njs_unit_test_t  njs_test[] =
       njs_str("Infinity") },
 
     { njs_str("Infinity.toString(NaN)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: radix argument must be between 2 and 36") },
 
     { njs_str("Infinity.toString({})"),
-      njs_str("RangeError") },
+      njs_str("RangeError: radix argument must be between 2 and 36") },
 
     { njs_str("Infinity.toString(Infinity)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: radix argument must be between 2 and 36") },
 
     { njs_str("NaN.toString()"),
       njs_str("NaN") },
@@ -648,13 +648,13 @@ static njs_unit_test_t  njs_test[] =
       njs_str("NaN") },
 
     { njs_str("NaN.toString(Infinity)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: radix argument must be between 2 and 36") },
 
     { njs_str("NaN.toString({})"),
-      njs_str("RangeError") },
+      njs_str("RangeError: radix argument must be between 2 and 36") },
 
     { njs_str("NaN.toString(NaN)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: radix argument must be between 2 and 36") },
 
     { njs_str("1.2312313132.toString(14)"),
       njs_str("1.3346da6d5d455c") },
@@ -8383,13 +8383,13 @@ static njs_unit_test_t  njs_test[] =
       njs_str("0") },
 
     { njs_str("String.fromCodePoint('_')"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid code point") },
 
     { njs_str("String.fromCharCode(65.14)"),
       njs_str("A") },
 
     { njs_str("String.fromCodePoint(3.14)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid code point") },
 
     { njs_str("String.fromCharCode(65.14 + 65536)"),
       njs_str("A") },
@@ -8428,7 +8428,7 @@ static njs_unit_test_t  njs_test[] =
       njs_str("\n") },
 
     { njs_str("String.fromCodePoint(1114111 + 1)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid code point") },
 
     { njs_str("String.fromCharCode(65, 90) + String.fromCodePoint(65, 90)"),
       njs_str("AZAZ") },
@@ -9809,22 +9809,22 @@ static njs_unit_test_t  njs_test[] =
       njs_str("") },
 
     { njs_str("'abc'.repeat(Infinity)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid count value") },
 
     { njs_str("'abc'.repeat(-1)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid count value") },
 
     { njs_str("''.repeat(-1)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid count value") },
 
     { njs_str("'a'.repeat(2147483647)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid string length") },
 
     { njs_str("'a'.repeat(2147483648)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid string length") },
 
     { njs_str("'a'.repeat(Infinity)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid count value") },
 
     { njs_str("'a'.repeat(NaN)"),
       njs_str("") },
@@ -9839,10 +9839,10 @@ static njs_unit_test_t  njs_test[] =
       njs_str("") },
 
     { njs_str("'aaaaaaaa'.repeat(2**64+1)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid count value") },
 
     { njs_str("''.repeat(Infinity)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid count value") },
 
     { njs_str("''.repeat(NaN)"),
       njs_str("") },
@@ -9866,7 +9866,7 @@ static njs_unit_test_t  njs_test[] =
       njs_str("abc") },
 
     { njs_str("'abc'.padStart(2147483647)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid string length") },
 
     { njs_str("'abc'.padStart(2147483646, '')"),
       njs_str("abc") },
@@ -9920,7 +9920,7 @@ static njs_unit_test_t  njs_test[] =
       njs_str("я     ") },
 
     { njs_str("'я'.padEnd(2147483647)"),
-      njs_str("RangeError") },
+      njs_str("RangeError: invalid string length") },
 
     { njs_str("'я'.padEnd(2147483646, '')"),
       njs_str("я") },
@@ -23050,7 +23050,7 @@ static njs_unit_test_t  njs_backtraces_test[] =
               "    at main (:1)\n") },
 
     { njs_str("''.repeat(-1)"),
-      njs_str("RangeError\n"
+      njs_str("RangeError: invalid count value\n"
               "    at String.prototype.repeat (native)\n"
               "    at main (:1)\n") },
 


### PR DESCRIPTION
Ensuring that buf is always initialized in njs_throw_error_va() and njs_error_fmt_new(), by requiring fmt to always be non NULL.

This fixes GCC warnings like:
169 | njs_unicode_decode_t ctx;
| ^
In function ‘njs_utf8_length’,
   inlined from ‘njs_error_new’ at src/njs_error.c:39:14,
   inlined from ‘njs_throw_error_va’ at src/njs_error.c:69:5:
   src/njs_utf8.h:141:12: error: ‘buf’ may be used uninitialized
   [-Werror=maybe-uninitialized]
   141 | return njs_utf8_stream_length(&ctx, p, len, 1, 1, NULL);

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
