### PR TITLE
fix(types): NgxKeyValuePair is actually an array

### DIFF
--- a/ts/ngx_core.d.ts
+++ b/ts/ngx_core.d.ts
@@ -250,7 +250,7 @@ interface NgxFetchOptions {
 declare class SharedMemoryError extends Error {}
 
 type NgxSharedDictValue = string | number;
-type NgxKeyValuePair<V> = { key: string, value: V };
+type NgxKeyValuePair<V> = [string, V];
 
 /**
  * Interface of a dictionary shared among the working processes.


### PR DESCRIPTION
### Proposed changes

Correct the type definition for `NgxSharedDict.items()`. At runtime, I found out it returns an array of `[key, value]` objects, just like `Object.items()`. As documented here https://nginx.org/en/docs/njs/reference.html#dict_items

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes

## Minimal reproduction
```
function dumpItems(r) {
  ngx.shared.myarray.set("hello", "world")
  console.log(ngx.shared.myarray.items()[0])
}
```
Console output
```
2024/07/30 12:14:42 [info] 22#22: *1 js: ['hello','world']
```