### PR TITLE
feat(njs): expose capture group variables

### DIFF
--- a/nginx/t/js_capture_variables.t
+++ b/nginx/t/js_capture_variables.t
@@ -1,0 +1,101 @@
+#!/usr/bin/perl
+
+# (C) Thomas P.
+
+# Tests for http njs module, reading location capture variables.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /njs {
+            js_content test.njs;
+        }
+
+        location ~ /(.+)/(.+) {
+            js_content test.variables;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    function variables(r) {
+        return r.return(200, `"\${r.variables[r.args.index]}"`);
+    }
+
+    function test_njs(r) {
+        r.return(200, njs.version);
+    }
+
+    export default {njs:test_njs, variables};
+
+EOF
+
+$t->try_run('no njs capture variables')->plan(4);
+
+###############################################################################
+
+TODO: {
+local $TODO = 'not yet' unless has_version('0.8.6');
+
+like(http_get('/test/hello?index=0'), qr/"\/test\/hello"/, 'global capture');
+like(http_get('/test/hello?index=1'), qr/"test"/, 'local capture 1');
+like(http_get('/test/hello?index=2'), qr/"hello"/, 'local capture 2');
+like(http_get('/test/hello?index=3'), qr/"undefined"/, 'undefined capture');
+
+}
+
+###############################################################################
+
+sub has_version {
+	my $need = shift;
+
+	http_get('/njs') =~ /^([.0-9]+)$/m;
+
+	my @v = split(/\./, $1);
+	my ($n, $v);
+
+	for $n (split(/\./, $need)) {
+		$v = shift @v || 0;
+		return 0 if $n > $v;
+		return 1 if $v > $n;
+	}
+
+	return 1;
+}
+
+###############################################################################


### PR DESCRIPTION
### Proposed changes

This PR exposes capture group variables like `$1`, `$2` to njs scripts in the `Request.variables` object, avoiding duplicate parsing to determine this value (on nginx side and on njs side).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes

I'm not very familiar with the testing framework of this project so I couldn't test everything, here's my test scenario though (it makes sure we handle limits correctly and ensures previous variables are still accessible).
<details>
  <summary>Testing scenario</summary>
    
```javascript
// njs/test.js
function handler(r) {
  for (let i = 0; i < 10; i++) {
    console.log(`${i}: ${r.variables[i.toString()]}`);
  }
  console.log(`host: ${r.variables["http_host"]}`);
  r.return(200, `OK ${r.variables.http_host}`);
}

export default {handler}
```

```
# nginx.conf
daemon off;
worker_processes 1;

# Make sure JS log messages will appear on the console
error_log stderr info;

events {
  worker_connections 1024;
}

pid /tmp/nginx/run.pid;


http {
  access_log off;

  # Get nginx to start
  client_body_temp_path /tmp/nginx/body_tmp;
  proxy_temp_path /tmp/nginx/proxy_tmp;
  fastcgi_temp_path /tmp/nginx/fcgi_tmp;
  uwsgi_temp_path /tmp/nginx/uwsgi;
  scgi_temp_path /tmp/nginx/scgi;

  js_path "./njs/";
  js_import test from test.js;
  default_type  text/plain;

  server {
    listen       9090;
    # Define various locations with more or less matching groups
    location = /no_match {
      js_content test.handler;
    }
    location ~ ^/(.+)/(.+)/(.+)/(.+) {
      js_content test.handler;
    }
    location ~ ^/(.+)/(.+)/(.+) {
      js_content test.handler;
    }
    location ~ ^/(.+)/(.+) {
      js_content test.handler;
    }
    location ~ ^/(.+) {
      js_content test.handler;
    }
  }
}
```

Get URLS:
* /no_match
* /abc/def/ghi/jkl
* /abc/def/ghi
* /abc/def
* /abc

Logs look like this
```
2024/07/30 18:00:34 [info] 53869#0: *1 js: 0: /abc/def/ghi/jkl
2024/07/30 18:00:34 [info] 53869#0: *1 js: 1: abc
2024/07/30 18:00:34 [info] 53869#0: *1 js: 2: def
2024/07/30 18:00:34 [info] 53869#0: *1 js: 3: ghi
2024/07/30 18:00:34 [info] 53869#0: *1 js: 4: jkl
2024/07/30 18:00:34 [info] 53869#0: *1 js: 5: undefined
2024/07/30 18:00:34 [info] 53869#0: *1 js: 6: undefined
2024/07/30 18:00:34 [info] 53869#0: *1 js: 7: undefined
2024/07/30 18:00:34 [info] 53869#0: *1 js: 8: undefined
2024/07/30 18:00:34 [info] 53869#0: *1 js: 9: undefined
2024/07/30 18:00:34 [info] 53869#0: *1 js: host: localhost:9090
```
</details>

---
Inspired by https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_variable.c#L42