### PR TITLE
feat(js_set): add nocache flag for uncacheable variables

### DIFF
--- a/nginx/ngx_js.h
+++ b/nginx/ngx_js.h
@@ -31,6 +31,8 @@
 #define NGX_JS_BOOL_TRUE    1
 #define NGX_JS_BOOL_UNSET   2
 
+#define NGX_NJS_VAR_NOCACHE 1
+
 #define ngx_js_buffer_type(btype) ((btype) & ~NGX_JS_DEPRECATED)
 
 
@@ -135,6 +137,12 @@ typedef struct {
 typedef struct {
     NGX_JS_COMMON_LOC_CONF;
 } ngx_js_loc_conf_t;
+
+
+typedef struct {
+    ngx_str_t fname;
+    unsigned  flags;
+} ngx_js_set_t;
 
 
 struct ngx_js_ctx_s {

--- a/nginx/t/js_variables_nocache.t
+++ b/nginx/t/js_variables_nocache.t
@@ -1,0 +1,99 @@
+#!/usr/bin/perl
+
+# (C) Thomas P.
+
+# Tests for http njs module, setting non-cacheable nginx variables.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http rewrite/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_set $nocache_var   test.variable nocache;
+    js_set $default_var   test.variable;
+    js_set $callcount_var test.callCount nocache;
+
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /default_var {
+            set $a $default_var;
+            set $b $default_var;
+            return 200 '"$a/$b"';
+        }
+
+        location /nocache_var {
+            set $a $nocache_var;
+            set $b $nocache_var;
+            return 200 '"$a/$b"';
+        }
+
+        location /callcount_var {
+            set $a $callcount_var;
+            set $b $callcount_var;
+            return 200 '"$a/$b"';
+        }
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    function variable(r) {
+        return Math.random().toFixed(16);
+    }
+
+    let n = 0;
+    function callCount(r) {
+        return (n += 1).toString();
+    }
+
+    export default {variable, callCount};
+
+EOF
+
+$t->try_run('no nocache njs variables')->plan(3);
+
+###############################################################################
+
+# We use backreferences to make sure the same value was returned for the two uses
+like(http_get('/default_var'), qr/"(.+)\/\1"/, 'cached variable');
+# Negative lookaheads don't capture, hence the .+ after it
+like(http_get('/nocache_var'), qr/"(.+)\/(?!\1).+"/, 'noncacheable variable');
+
+TODO: {
+    local $TODO = "Needs upstream nginx patch https://mailman.nginx.org/pipermail/nginx-devel/2024-August/N7VFIYUKSZFUIAO24OJODKQGTP63R5NV.html";
+
+    # Without the patch, this will give 2/4 (calls are duplicated)
+    like(http_get('/callcount_var'), qr/"1\/2"/, 'callcount variable');
+}
+
+###############################################################################

--- a/nginx/t/stream_js_variables_nocache.t
+++ b/nginx/t/stream_js_variables_nocache.t
@@ -1,0 +1,94 @@
+#!/usr/bin/perl
+
+# (C) Thomas P.
+
+# Tests for stream njs module, setting non-cacheable nginx variables.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_return/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    %%TEST_GLOBALS_STREAM%%
+
+    js_set $nocache_var   test.variable nocache;
+    js_set $default_var   test.variable;
+    js_set $callcount_var test.callCount nocache;
+
+    js_import test.js;
+
+    server {
+        listen  127.0.0.1:8081;
+        set     $a $default_var;
+        set     $b $default_var;
+        return  '"$a/$b"';
+    }
+
+    server {
+        listen  127.0.0.1:8082;
+        set     $a $nocache_var;
+        set     $b $nocache_var;
+        return  '"$a/$b"';
+    }
+
+    server {
+        listen  127.0.0.1:8083;
+        set     $a $callcount_var;
+        set     $b $callcount_var;
+        return  '"$a/$b"';
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    function variable(r) {
+        return Math.random().toFixed(16);
+    }
+
+    let n = 0;
+    function callCount(r) {
+        return (n += 1).toString();
+    }
+
+    export default {variable, callCount};
+
+EOF
+
+$t->try_run('no nocache stream njs variables')->plan(3);
+
+###############################################################################
+
+# We use backreferences to make sure the same value was returned for the two uses
+like(stream('127.0.0.1:' . port(8081))->read(), qr/"(.+)\/\1"/, 'cached variable');
+# Negative lookaheads don't capture, hence the .+ after it
+like(stream('127.0.0.1:' . port(8082))->read(), qr/"(.+)\/(?!\1).+"/, 'noncacheable variable');
+like(stream('127.0.0.1:' . port(8083))->read(), qr/"1\/2"/, 'callcount variable');
+
+$t->stop();
+
+###############################################################################


### PR DESCRIPTION
### Proposed changes

This commit adds support for an additional `nocache` flag in `js_set` directives. If set, the resulting nginx variable will have no_cacheable set to 1. This enables us to dynamically recompute a variable if the context changed (for example, in case of an internal redirection). It also gives some control over the phase when variables are computed without needing to explain phases in the docs: as the variable is not cached, it is recomputed every time it is needed. Advanced users needing to hack something to get a JS code to run at a certain point in the config can simply refer to a nocached js_set variable in the corresponding directives and it is guaranteed the variable getter will be called when this directive evaluates the variable.

Should they want to benefit from this without performing too many calls, users can cache the result in a rewrite variable: `set $cached_variable $js_variable;`

I'm not very familiar with the testing framework of this project, but here's a test case.

<details>
  <summary>Test case</summary>
 
```
# nginx.conf - server block with njs loaded
  default_type  text/plain;

  js_path "./njs/";
  js_import test from test.js;
  js_set $test test.getTest nocache;

  server {
    listen       9090;

    location / {
      set $cached_test $test;
      if ($cached_test = "hello") {
        js_content test.redirect;
      }
      if ($cached_test != "hello") {
        return 200 $cached_test;
      }
    }
  }
```

```javascript
// njs/test.js
function getTest(r) {
  console.log('getTest call - URI is ' + r.uri);
  return "hello" + r.uri.substr(1);
}

function redirect(r) {
  r.internalRedirect('/test');
}

export default {getTest, redirect};
 ```

Expected result
```
curl 127.0.0.1:9090
hellotest
```

Expected logs
```
2024/08/07 12:06:52 [info] 40470#0: *1 js: getTest call - URI is /
2024/08/07 12:06:52 [info] 40470#0: *1 js: getTest call - URI is /test
```
JS calls may be duplicated due to what appears to be a bug in the way the rewrite handler evaluates complex expressions - I have sent [a patch](https://mailman.nginx.org/pipermail/nginx-devel/2024-August/N7VFIYUKSZFUIAO24OJODKQGTP63R5NV.html) to upstream nginx to address it.
</details>

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
