### PR TITLE
QuickJS modules.

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -84,3 +84,68 @@ jobs:
           TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
           TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so;"
           TEST_NGINX_VERBOSE: 1
+
+      - name: Create LSAN suppression file
+        run: |
+          cat << EOF > lsan_suppressions.txt
+          leak:ngx_event_process_init
+          EOF
+
+      - name: Configure and build nginx and njs modules with quickjs, static modules
+        run: |
+          cd nginx-source
+          $NGINX_CONFIGURE_CMD --with-cc-opt="$CC_OPT -I${{ github.workspace }}/quickjs -fsanitize=address" --with-ld-opt="$LD_OPT -L${{ github.workspace }}/quickjs -fsanitize=address" --add-module=../nginx || cat objs/autoconf.err
+          $MAKE_UTILITY -j$(nproc)
+
+      - name: Test njs modules, static modules
+        run: |
+          ulimit -c unlimited
+          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+        env:
+          TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
+          TEST_NGINX_VERBOSE: 1
+          ASAN_OPTIONS: "detect_odr_violation=0:report_globals=0"
+          LSAN_OPTIONS: "suppressions=${{ github.workspace }}/lsan_suppressions.txt"
+
+      - name: Test njs modules (js_engine qjs), static modules
+        run: |
+          ulimit -c unlimited
+          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+        env:
+          TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
+          TEST_NGINX_GLOBALS_HTTP: "js_engine qjs;"
+          TEST_NGINX_GLOBALS_STREAM: "js_engine qjs;"
+          TEST_NGINX_VERBOSE: 1
+          ASAN_OPTIONS: "detect_odr_violation=0:report_globals=0"
+          LSAN_OPTIONS: "suppressions=${{ github.workspace }}/lsan_suppressions.txt"
+
+      - name: Configure and build nginx and njs modules with quickjs, dynamic modules
+        run: |
+          cd nginx-source
+          $NGINX_CONFIGURE_CMD --with-debug --with-cc-opt="$CC_OPT -I${{ github.workspace }}/quickjs -fsanitize=address" --with-ld-opt="$LD_OPT -L${{ github.workspace }}/quickjs -fsanitize=address" --add-dynamic-module=../nginx || cat objs/autoconf.err
+          $MAKE_UTILITY -j$(nproc) modules
+          $MAKE_UTILITY -j$(nproc)
+
+      - name: Test njs modules, dynamic modules
+        run: |
+          ulimit -c unlimited
+          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+        env:
+          TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
+          TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so;"
+          TEST_NGINX_VERBOSE: 1
+          ASAN_OPTIONS: "detect_odr_violation=0:report_globals=0:fast_unwind_on_malloc=0"
+          LSAN_OPTIONS: "suppressions=${{ github.workspace }}/lsan_suppressions.txt"
+
+      - name: Test njs modules (js_engine qjs), dynamic modules
+        run: |
+          ulimit -c unlimited
+          prove -v -j$(nproc) -Inginx-tests/lib --state=save nginx/t . || prove -v -Inginx-tests/lib --state=failed
+        env:
+          TEST_NGINX_BINARY: "${{ github.workspace }}/nginx-source/objs/nginx"
+          TEST_NGINX_GLOBALS: "load_module ${{ github.workspace }}/nginx-source/objs/ngx_stream_js_module.so; load_module ${{ github.workspace }}/nginx-source/objs/ngx_http_js_module.so;"
+          TEST_NGINX_GLOBALS_HTTP: "js_engine qjs;"
+          TEST_NGINX_GLOBALS_STREAM: "js_engine qjs;"
+          TEST_NGINX_VERBOSE: 1
+          ASAN_OPTIONS: "detect_odr_violation=0:report_globals=0:fast_unwind_on_malloc=0"
+          LSAN_OPTIONS: "suppressions=${{ github.workspace }}/lsan_suppressions.txt"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check out and build quickjs
         run: |
           git clone https://github.com/bellard/quickjs
-          cd quickjs && curl -OL http://pp.nginx.com/pluknet/quickjs.patch && git apply quickjs.patch
+          cd quickjs
           CFLAGS=$CC_OPT LDFLAGS=$LD_OPT $MAKE_UTILITY -j$(nproc) libquickjs.a
 
       - name: Configure and make njs

--- a/nginx/config
+++ b/nginx/config
@@ -3,6 +3,7 @@ ngx_addon_name="ngx_js_module"
 NJS_OPENSSL=${NJS_OPENSSL:-YES}
 NJS_LIBXSLT=${NJS_LIBXSLT:-YES}
 NJS_ZLIB=${NJS_ZLIB:-YES}
+NJS_QUICKJS=${NJS_QUICKJS:-YES}
 
 NJS_DEPS="$ngx_addon_dir/ngx_js.h \
     $ngx_addon_dir/ngx_js_fetch.h \
@@ -12,9 +13,78 @@ NJS_SRCS="$ngx_addon_dir/ngx_js.c \
     $ngx_addon_dir/ngx_js_regex.c \
     $ngx_addon_dir/ngx_js_shared_dict.c"
 
+QJS_DEPS=""
+QJS_SRCS=""
+
 NJS_OPENSSL_LIB=
 NJS_XSLT_LIB=
 NJS_ZLIB_LIB=
+NJS_QUICKJS_LIB=
+NJS_QUICKJS_INC=
+NJS_HAVE_QUICKJS=
+
+if [ $NJS_QUICKJS != NO ]; then
+
+    ngx_feature="QuickJS library -lquickjs.lto"
+    ngx_feature_name=NJS_HAVE_QUICKJS
+    ngx_feature_run=yes
+    ngx_feature_incs="#if defined(__GNUC__) && (__GNUC__ >= 8)
+                      #pragma GCC diagnostic push
+                      #pragma GCC diagnostic ignored \"-Wcast-function-type\"
+                      #endif
+
+                      #include <quickjs.h>"
+    ngx_feature_path=""
+    ngx_feature_libs="-lquickjs.lto -lm -ldl -lpthread"
+    ngx_feature_test="JSRuntime *rt;
+
+                      rt = JS_NewRuntime();
+                      (void) JS_GetClassID;
+                      JS_FreeRuntime(rt);
+                      return 0;"
+    . auto/feature
+
+    if [ $ngx_found = no ]; then
+        ngx_feature="QuickJS library -lquickjs"
+        ngx_feature_libs="-lquickjs -lm -ldl -lpthread"
+
+        . auto/feature
+    fi
+
+    if [ $ngx_found = no ]; then
+        ngx_feature="QuickJS library -I/usr/include/quickjs/ -L/usr/lib/quickjs/ -lquickjs.lto"
+        ngx_feature_path="/usr/include/quickjs/"
+        ngx_feature_libs="-L/usr/lib/quickjs/ -lquickjs.lto -lm -ldl -lpthread"
+
+        . auto/feature
+    fi
+
+    if [ $ngx_found = no ]; then
+        ngx_feature="QuickJS library -I/usr/include/quickjs/ -L/usr/lib/quickjs/ -lquickjs"
+        ngx_feature_libs="-L/usr/lib/quickjs/ -lquickjs -lm -ldl -lpthread"
+
+        . auto/feature
+    fi
+
+    if [ $ngx_found = yes ]; then
+
+        ngx_feature="QuickJS JS_NewTypedArray()"
+        ngx_feature_test="(void) JS_NewTypedArray;
+                          return 0;"
+
+        . auto/feature
+
+        if [ $ngx_found = yes ]; then
+            have=NJS_HAVE_QUICKJS_NEW_TYPED_ARRAY . auto/have
+        fi
+
+        NJS_HAVE_QUICKJS=YES
+        NJS_QUICKJS_LIB="$ngx_feature_libs"
+        NJS_QUICKJS_INC="$ngx_feature_path"
+
+        echo " enabled QuickJS engine"
+    fi
+fi
 
 if [ $NJS_OPENSSL != NO ]; then
     NJS_OPENSSL_LIB=OPENSSL
@@ -37,17 +107,30 @@ if [ $NJS_ZLIB != NO ]; then
     have=NJS_HAVE_ZLIB . auto/have
     NJS_SRCS="$NJS_SRCS $ngx_addon_dir/../external/njs_zlib_module.c"
 
+    if [ "$NJS_HAVE_QUICKJS" = "YES" ];  then
+        NJS_SRCS="$NJS_SRCS $ngx_addon_dir/../external/qjs_zlib_module.c"
+    fi
+
     echo " enabled zlib module"
+fi
+
+
+NJS_ENGINE_DEP="$ngx_addon_dir/../build/libnjs.a"
+NJS_ENGINE_LIB="$ngx_addon_dir/../build/libnjs.a"
+if [ "$NJS_HAVE_QUICKJS" = "YES" ];  then
+    NJS_ENGINE_DEP="$ngx_addon_dir/../build/libqjs.a"
+    NJS_ENGINE_LIB="$ngx_addon_dir/../build/libnjs.a $ngx_addon_dir/../build/libqjs.a"
 fi
 
 if [ $HTTP != NO ]; then
     ngx_module_type=HTTP_AUX_FILTER
     ngx_module_name=ngx_http_js_module
-    ngx_module_incs="$ngx_addon_dir/../src $ngx_addon_dir/../build"
-    ngx_module_deps="$ngx_addon_dir/../build/libnjs.a $NJS_DEPS"
-    ngx_module_srcs="$ngx_addon_dir/ngx_http_js_module.c $NJS_SRCS"
+    ngx_module_incs="$ngx_addon_dir/../src $ngx_addon_dir/../build \
+                     $NJS_QUICKJS_INC"
+    ngx_module_deps="$NJS_ENGINE_DEP $NJS_DEPS $QJS_DEPS"
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_js_module.c $NJS_SRCS $QJS_SRCS"
     ngx_module_libs="PCRE $NJS_OPENSSL_LIB $NJS_XSLT_LIB $NJS_ZLIB_LIB \
-                     $ngx_addon_dir/../build/libnjs.a -lm"
+                     $NJS_QUICKJS_LIB $NJS_ENGINE_LIB -lm"
 
     . auto/module
 
@@ -59,11 +142,12 @@ fi
 if [ $STREAM != NO ]; then
     ngx_module_type=STREAM
     ngx_module_name=ngx_stream_js_module
-    ngx_module_incs="$ngx_addon_dir/../src $ngx_addon_dir/../build"
-    ngx_module_deps="$ngx_addon_dir/../build/libnjs.a $NJS_DEPS"
-    ngx_module_srcs="$ngx_addon_dir/ngx_stream_js_module.c $NJS_SRCS"
+    ngx_module_incs="$ngx_addon_dir/../src $ngx_addon_dir/../build \
+                     $NJS_QUICKJS_INC"
+    ngx_module_deps="$NJS_ENGINE_DEP $NJS_DEPS $QJS_DEPS"
+    ngx_module_srcs="$ngx_addon_dir/ngx_stream_js_module.c $NJS_SRCS $QJS_SRCS"
     ngx_module_libs="PCRE $NJS_OPENSSL_LIB $NJS_XSLT_LIB $NJS_ZLIB_LIB \
-                     $ngx_addon_dir/../build/libnjs.a -lm"
+                     $NJS_QUICKJS_LIB $NJS_ENGINE_LIB -lm"
 
     . auto/module
 fi

--- a/nginx/config.make
+++ b/nginx/config.make
@@ -3,7 +3,15 @@ cat << END                                            >> $NGX_MAKEFILE
 $ngx_addon_dir/../build/libnjs.a: $NGX_MAKEFILE
 	cd $ngx_addon_dir/.. \\
 	&& if [ -f build/Makefile ]; then \$(MAKE) clean; fi \\
-	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" ./configure --no-openssl --no-libxml2 --no-zlib --no-pcre \\
+	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" ./configure --no-openssl \\
+		--no-libxml2 --no-zlib --no-pcre --no-quickjs \\
 	&& \$(MAKE) libnjs
+
+$ngx_addon_dir/../build/libqjs.a: $NGX_MAKEFILE
+	cd $ngx_addon_dir/.. \\
+	&& if [ -f build/Makefile ]; then \$(MAKE) clean; fi \\
+	&& CFLAGS="\$(CFLAGS)" CC="\$(CC)" ./configure --no-openssl \\
+		--no-libxml2 --no-zlib --no-pcre \\
+	&& \$(MAKE) libnjs libqjs
 
 END

--- a/nginx/t/js_engine.t
+++ b/nginx/t/js_engine.t
@@ -1,0 +1,140 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) Nginx, Inc.
+
+# Tests for http njs module, js_engine directive.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /njs {
+            js_content test.njs;
+        }
+
+        location /njs/ {
+            proxy_pass http://127.0.0.1:8081/;
+        }
+
+        location /qjs/ {
+            proxy_pass http://127.0.0.1:8082/;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8081;
+        server_name  localhost;
+
+        js_engine njs;
+
+        location /test {
+            js_content test.test;
+        }
+
+        location /override {
+            js_engine qjs;
+            js_content test.test;
+        }
+    }
+
+    server {
+        listen       127.0.0.1:8082;
+        server_name  localhost;
+
+        js_engine qjs;
+
+        location /test {
+            js_content test.test;
+        }
+
+        location /override {
+            js_engine njs;
+            js_content test.test;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    function test_njs(r) {
+        r.return(200, njs.version);
+    }
+
+    function test(r) {
+        r.return(200, njs.engine);
+    }
+
+    export default {njs: test_njs, test};
+
+EOF
+
+$t->try_run('no njs js_engine')->plan(4);
+
+###############################################################################
+
+TODO: {
+local $TODO = 'not yet' unless has_version('0.8.6');
+
+like(http_get('/njs/test'), qr/njs/, 'js_engine njs server');
+like(http_get('/njs/override'), qr/QuickJS/, 'js_engine override');
+like(http_get('/qjs/test'), qr/QuickJS/, 'js_engine qjs server');
+like(http_get('/qjs/override'), qr/njs/, 'js_engine override');
+
+}
+
+$t->stop();
+
+###############################################################################
+
+sub has_version {
+	my $need = shift;
+
+	http_get('/njs') =~ /^([.0-9]+)$/m;
+
+	my @v = split(/\./, $1);
+	my ($n, $v);
+
+	for $n (split(/\./, $need)) {
+		$v = shift @v || 0;
+		return 0 if $n > $v;
+		return 1 if $v > $n;
+	}
+
+	return 1;
+}
+
+###############################################################################

--- a/nginx/t/js_fetch.t
+++ b/nginx/t/js_fetch.t
@@ -52,6 +52,10 @@ http {
             js_content test.njs;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /broken {
             js_content test.broken;
         }
@@ -132,6 +136,10 @@ $t->write_file('json', '{"a":[1,2], "b":{"c":"FIELD"}}');
 $t->write_file('test.js', <<EOF);
     function test_njs(r) {
         r.return(200, njs.version);
+    }
+
+    function engine(r) {
+        r.return(200, njs.engine);
     }
 
     function body(r) {
@@ -398,10 +406,14 @@ $t->write_file('test.js', <<EOF);
 
      export default {njs: test_njs, body, broken, broken_response, body_special,
                      chain, chunked_ok, chunked_fail, header, header_iter,
-                     host_header, multi, loc, property};
+                     host_header, multi, loc, property, engine};
 EOF
 
-$t->try_run('no njs.fetch')->plan(36);
+$t->try_run('no njs.fetch');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(36);
 
 $t->run_daemon(\&http_daemon, port(8082));
 $t->waitforsocket('127.0.0.1:' . port(8082));

--- a/nginx/t/js_fetch_https.t
+++ b/nginx/t/js_fetch_https.t
@@ -48,6 +48,10 @@ http {
             js_content test.njs;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /https {
             js_content test.https;
         }
@@ -102,6 +106,10 @@ $t->write_file('test.js', <<EOF);
         r.return(200, njs.version);
     }
 
+    function engine(r) {
+        r.return(200, njs.engine);
+    }
+
     function https(r) {
         var url = `https://\${r.args.domain}:$p1/loc`;
         var opt = {};
@@ -116,7 +124,7 @@ $t->write_file('test.js', <<EOF);
         .catch(e => r.return(501, e.message))
     }
 
-    export default {njs: test_njs, https};
+    export default {njs: test_njs, https, engine};
 EOF
 
 my $d = $t->testdir();
@@ -186,7 +194,11 @@ foreach my $name ('default.example.com', '1.example.com') {
 		. $t->read_file('intermediate.crt'));
 }
 
-$t->try_run('no njs.fetch')->plan(7);
+$t->try_run('no njs.fetch');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(7);
 
 $t->run_daemon(\&dns_daemon, port(8981), $t);
 $t->waitforfile($t->testdir . '/' . port(8981));

--- a/nginx/t/js_fetch_objects.t
+++ b/nginx/t/js_fetch_objects.t
@@ -45,6 +45,10 @@ http {
             js_content test.njs;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /headers {
             js_content test.headers;
         }
@@ -86,6 +90,10 @@ my $p0 = port(8080);
 $t->write_file('test.js', <<EOF);
     function test_njs(r) {
         r.return(200, njs.version);
+    }
+
+    function engine(r) {
+        r.return(200, njs.engine);
     }
 
     function header(r) {
@@ -501,11 +509,15 @@ $t->write_file('test.js', <<EOF);
         run(r, tests);
     }
 
-     export default {njs: test_njs, body, headers, request, response, fetch,
-                     fetch_multi_header};
+     export default {njs: test_njs, engine, body, headers, request, response,
+                     fetch, fetch_multi_header};
 EOF
 
-$t->try_run('no njs')->plan(5);
+$t->try_run('no njs');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(5);
 
 ###############################################################################
 

--- a/nginx/t/js_fetch_resolver.t
+++ b/nginx/t/js_fetch_resolver.t
@@ -50,6 +50,10 @@ http {
             js_content test.njs;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /dns {
             js_content test.dns;
 
@@ -104,6 +108,10 @@ $t->write_file('test.js', <<EOF);
         r.return(200, njs.version);
     }
 
+    function engine(r) {
+        r.return(200, njs.engine);
+    }
+
     const p0 = $p0;
     const p1 = $p1;
 
@@ -133,10 +141,14 @@ $t->write_file('test.js', <<EOF);
         r.return(c, `\${v.host}:\${v.request_method}:\${foo}:\${bar}:\${body}`);
     }
 
-     export default {njs: test_njs, dns, loc};
+     export default {njs: test_njs, dns, loc, engine};
 EOF
 
-$t->try_run('no njs.fetch')->plan(5);
+$t->try_run('no njs.fetch');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(5);
 
 $t->run_daemon(\&dns_daemon, port(8981), $t);
 $t->waitforfile($t->testdir . '/' . port(8981));

--- a/nginx/t/js_fetch_timeout.t
+++ b/nginx/t/js_fetch_timeout.t
@@ -47,6 +47,10 @@ http {
             js_content test.njs;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /normal_timeout {
             js_content test.timeout_test;
         }
@@ -80,6 +84,10 @@ $t->write_file('test.js', <<EOF);
         r.return(200, njs.version);
     }
 
+    function engine(r) {
+        r.return(200, njs.engine);
+    }
+
     async function timeout_test(r) {
         let rs = await Promise.allSettled([
             'http://127.0.0.1:$p1/normal_reply',
@@ -102,10 +110,15 @@ $t->write_file('test.js', <<EOF);
         setTimeout((r) => { r.return(200); }, 250, r, 0);
     }
 
-     export default {njs: test_njs, timeout_test, normal_reply, delayed_reply};
+     export default {njs: test_njs, engine, timeout_test, normal_reply,
+                     delayed_reply};
 EOF
 
-$t->try_run('no js_fetch_timeout')->plan(2);
+$t->try_run('no js_fetch_timeout');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(2);
 
 ###############################################################################
 

--- a/nginx/t/js_periodic.t
+++ b/nginx/t/js_periodic.t
@@ -71,6 +71,10 @@ http {
             js_periodic test.timeout_exception interval=30ms;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /fetch_ok {
             return 200 'ok';
         }
@@ -119,6 +123,10 @@ my $p0 = port(8080);
 
 $t->write_file('test.js', <<EOF);
     import fs from 'fs';
+
+    function engine(r) {
+        r.return(200, njs.engine);
+    }
 
     function affinity() {
         ngx.shared.workers.set(ngx.worker_id, 1);
@@ -241,10 +249,14 @@ $t->write_file('test.js', <<EOF);
                      test_file, test_multiple_fetches, test_tick,
                      test_timeout_exception, test_timer, test_vars, tick,
                      tick_exception, timer, timer_exception,
-                     timeout_exception };
+                     timeout_exception, engine };
 EOF
 
-$t->try_run('no js_periodic')->plan(9);
+$t->try_run('no js_periodic');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(9);
 
 ###############################################################################
 

--- a/nginx/t/js_preload_object.t
+++ b/nginx/t/js_preload_object.t
@@ -45,6 +45,10 @@ http {
         js_import lib.js;
         js_preload_object lx from l.json;
 
+        location /engine {
+            js_content lib.engine;
+        }
+
         location /test {
             js_content lib.test;
         }
@@ -81,6 +85,10 @@ EOF
 $t->write_file('lib.js', <<EOF);
     function test(r) {
         r.return(200, ga + ' ' + g1.c.prop[0].a + ' ' + lx);
+    }
+
+    function engine(r) {
+        r.return(200, njs.engine);
     }
 
     function test_var(r) {
@@ -123,7 +131,7 @@ $t->write_file('lib.js', <<EOF);
         r.return(200, gg);
     }
 
-    export default {test, test_var, mutate, suffix};
+    export default {engine, test, test_var, mutate, suffix};
 
 EOF
 
@@ -151,7 +159,11 @@ $t->write_file('ga.json', '"ga loaded"');
 $t->write_file('l.json', '"l loaded"');
 $t->write_file('no_suffix', '"no_suffix loaded"');
 
-$t->try_run('no js_preload_object available')->plan(12);
+$t->try_run('no js_preload_object available');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(12);
 
 ###############################################################################
 

--- a/nginx/t/js_shared_dict.t
+++ b/nginx/t/js_shared_dict.t
@@ -51,6 +51,10 @@ http {
             js_content test.njs;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /add {
             js_content test.add;
         }
@@ -130,6 +134,10 @@ EOF
 $t->write_file('test.js', <<'EOF');
     function test_njs(r) {
         r.return(200, njs.version);
+    }
+
+    function engine(r) {
+        r.return(200, njs.engine);
     }
 
     function convertToValue(dict, v) {
@@ -257,7 +265,7 @@ $t->write_file('test.js', <<'EOF');
 
     function pop(r) {
         var dict = ngx.shared[r.args.dict];
-		var val = dict.pop(r.args.key);
+        var val = dict.pop(r.args.key);
         if (val == '') {
             val = 'empty';
 
@@ -302,10 +310,14 @@ $t->write_file('test.js', <<'EOF');
 
     export default { add, capacity, chain, clear, del, free_space, get, has,
                      incr, items, keys, name, njs: test_njs, pop, replace, set,
-                     set_clear, size, zones };
+                     set_clear, size, zones, engine };
 EOF
 
-$t->try_run('no js_shared_dict_zone')->plan(51);
+$t->try_run('no js_shared_dict_zone');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(51);
 
 ###############################################################################
 

--- a/nginx/t/stream_js_exit.t
+++ b/nginx/t/stream_js_exit.t
@@ -45,6 +45,10 @@ http {
         location /njs {
             js_content test.njs;
         }
+
+        location /engine {
+            js_content test.engine;
+        }
     }
 }
 
@@ -74,6 +78,10 @@ $t->write_file('test.js', <<EOF);
         r.return(200, njs.version);
     }
 
+    function engine(r) {
+        r.return(200, njs.engine);
+    }
+
     function access(s) {
         njs.on('exit', () => {
             var v = s.variables;
@@ -95,10 +103,14 @@ $t->write_file('test.js', <<EOF);
         });
     }
 
-    export default {njs: test_njs, access, filter};
+    export default {njs: test_njs, engine, access, filter};
 EOF
 
-$t->try_run('no stream njs available')->plan(2);
+$t->try_run('no stream njs available');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(2);
 
 $t->run_daemon(\&stream_daemon, port(8090));
 $t->waitforsocket('127.0.0.1:' . port(8090));

--- a/nginx/t/stream_js_fetch.t
+++ b/nginx/t/stream_js_fetch.t
@@ -46,6 +46,10 @@ http {
             js_content test.njs;
         }
 
+        location /engine {
+            js_content test.engine;
+        }
+
         location /validate {
             js_content test.validate;
         }
@@ -97,6 +101,10 @@ my $p = port(8080);
 $t->write_file('test.js', <<EOF);
     function test_njs(r) {
         r.return(200, njs.version);
+    }
+
+    function engine(r) {
+        r.return(200, njs.engine);
     }
 
     function validate(r) {
@@ -158,10 +166,14 @@ $t->write_file('test.js', <<EOF);
     }
 
     export default {njs: test_njs, validate, preread_verify, filter_verify,
-                    access_ok, access_nok};
+                    access_ok, access_nok, engine};
 EOF
 
-$t->try_run('no stream njs available')->plan(9);
+$t->try_run('no stream njs available');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(9);
 
 $t->run_daemon(\&stream_daemon, port(8090), port(8091));
 $t->waitforsocket('127.0.0.1:' . port(8090));

--- a/nginx/t/stream_js_object.t
+++ b/nginx/t/stream_js_object.t
@@ -33,35 +33,76 @@ daemon off;
 events {
 }
 
-stream {
-    %%TEST_GLOBALS_STREAM%%
-
-    js_set $test     test.test;
+http {
+    %%TEST_GLOBALS_HTTP%%
 
     js_import test.js;
 
     server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /engine {
+            js_content test.engine;
+        }
+    }
+}
+
+stream {
+    %%TEST_GLOBALS_STREAM%%
+
+    js_import test.js;
+
+    js_set $to_string            test.to_string;
+    js_set $define_prop          test.define_prop;
+    js_set $in_operator          test.in_operator;
+    js_set $redefine_proto       test.redefine_proto;
+    js_set $get_own_prop_descs   test.get_own_prop_descs;
+
+    server {
         listen  127.0.0.1:8081;
-        return  $test$status;
+        return  $to_string;
+    }
+
+    server {
+        listen  127.0.0.1:8082;
+        return  $define_prop$status;
+    }
+
+    server {
+        listen 127.0.0.1:8083;
+        return $in_operator;
+    }
+
+    server {
+        listen 127.0.0.1:8084;
+        return $redefine_proto;
+    }
+
+    server {
+        listen 127.0.0.1:8085;
+        return $get_own_prop_descs;
     }
 }
 
 EOF
 
 $t->write_file('test.js', <<EOF);
+    function engine(r) {
+        r.return(200, njs.engine);
+    }
+
     function to_string(s) {
-        return s.toString() === '[object Stream Session]';
+        return s.toString();
     }
 
     function define_prop(s) {
         Object.defineProperty(s.variables, 'status', {value:400});
-        return s.variables.status == 400;
+        return s.variables.status;
     }
 
     function in_operator(s) {
-        return ['status', 'unknown']
-               .map(v=>v in s.variables)
-               .toString() === 'true,false';
+        return ['status', 'unknown'].map(v=>v in s.variables).toString();
     }
 
     function redefine_proto(s) {
@@ -76,23 +117,27 @@ $t->write_file('test.js', <<EOF);
         return Object.getOwnPropertyDescriptors(s)['on'].value === s.on;
     }
 
-    function test(s) {
-        return [ to_string,
-                 define_prop,
-                 in_operator,
-                 redefine_proto,
-                 get_own_prop_descs,
-               ].every(v=>v(s));
-    }
-
-    export default {test};
+    export default { engine, to_string, define_prop, in_operator,
+                     redefine_proto, get_own_prop_descs };
 
 EOF
 
-$t->try_run('no njs stream session object')->plan(1);
+$t->try_run('no njs stream session object')->plan(5);
 
 ###############################################################################
 
-is(stream('127.0.0.1:' . port(8081))->read(), 'true400', 'var set');
+is(stream('127.0.0.1:' . port(8081))->read(), '[object Stream Session]',
+	'to_string');
+is(stream('127.0.0.1:' . port(8082))->read(), '400400', 'define_prop');
+is(stream('127.0.0.1:' . port(8083))->read(), 'true,false', 'in_operator');
+is(stream('127.0.0.1:' . port(8084))->read(), 'true', 'redefine_proto');
+
+SKIP: {
+	skip "In QuickJS methods are in the prototype", 1
+		if http_get('/engine') =~ /QuickJS$/m;
+
+is(stream('127.0.0.1:' . port(8085))->read(), 'true', 'get_own_prop_descs');
+
+}
 
 ###############################################################################

--- a/nginx/t/stream_js_preload_object.t
+++ b/nginx/t/stream_js_preload_object.t
@@ -33,6 +33,21 @@ daemon off;
 events {
 }
 
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_import main.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /engine {
+            js_content main.engine;
+        }
+    }
+}
+
 stream {
     %%TEST_GLOBALS_STREAM%%
 
@@ -104,14 +119,22 @@ $t->write_file('lib.js', <<EOF);
 EOF
 
 $t->write_file('main.js', <<EOF);
-    export default {bar: {p(s) {return g1.b[2]}}};
+    function engine(r) {
+        r.return(200, njs.engine);
+    }
+
+    export default {engine, bar: {p(s) {return g1.b[2]}}};
 
 EOF
 
 $t->write_file('g.json',
 	'{"a":1, "b":[1,2,"element",4,5], "c":{"prop":[{"a":3}]}}');
 
-$t->try_run('no js_preload_object available')->plan(2);
+$t->try_run('no js_preload_object available');
+
+plan(skip_all => 'not yet') if http_get('/engine') =~ /QuickJS$/m;
+
+$t->plan(2);
 
 ###############################################################################
 

--- a/src/qjs.h
+++ b/src/qjs.h
@@ -33,6 +33,12 @@
 #include <pthread.h>
 
 
+#define QJS_CORE_CLASS_ID_OFFSET  64
+#define QJS_CORE_CLASS_ID_BUFFER  (QJS_CORE_CLASS_ID_OFFSET)
+#define QJS_CORE_CLASS_ID_UINT8_ARRAY_CTOR (QJS_CORE_CLASS_ID_OFFSET + 1)
+#define QJS_CORE_CLASS_ID_LAST    (QJS_CORE_CLASS_ID_UINT8_ARRAY_CTOR)
+
+
 typedef JSModuleDef *(*qjs_addon_init_pt)(JSContext *ctx, const char *name);
 
 typedef struct {

--- a/src/qjs_buffer.c
+++ b/src/qjs_buffer.c
@@ -262,15 +262,12 @@ static JSClassDef qjs_buffer_class = {
 };
 
 
-static JSClassID qjs_buffer_class_id;
-
 #ifndef NJS_HAVE_QUICKJS_NEW_TYPED_ARRAY
 static JSClassDef qjs_uint8_array_ctor_class = {
     "Uint8ArrayConstructor",
     .finalizer = NULL,
 };
 
-static JSClassID qjs_uint8_array_ctor_id;
 #endif
 
 
@@ -354,7 +351,7 @@ qjs_buffer_ctor(JSContext *ctx, JSValueConst this_val, int argc,
         return ret;
     }
 
-    proto = JS_GetClassProto(ctx, qjs_buffer_class_id);
+    proto = JS_GetClassProto(ctx, QJS_CORE_CLASS_ID_BUFFER);
     JS_SetPrototype(ctx, ret, proto);
     JS_FreeValue(ctx, proto);
 
@@ -725,7 +722,7 @@ qjs_buffer_is_buffer(JSContext *ctx, JSValueConst this_val,
     JSValue proto, buffer_proto, ret;
 
     proto = JS_GetPrototype(ctx, argv[0]);
-    buffer_proto = JS_GetClassProto(ctx, qjs_buffer_class_id);
+    buffer_proto = JS_GetClassProto(ctx, QJS_CORE_CLASS_ID_BUFFER);
 
     ret = JS_NewBool(ctx, JS_VALUE_GET_TAG(argv[0]) == JS_TAG_OBJECT &&
                      JS_VALUE_GET_OBJ(buffer_proto) == JS_VALUE_GET_OBJ(proto));
@@ -2426,7 +2423,7 @@ qjs_buffer_alloc(JSContext *ctx, size_t size)
         return ret;
     }
 
-    proto = JS_GetClassProto(ctx, qjs_buffer_class_id);
+    proto = JS_GetClassProto(ctx, QJS_CORE_CLASS_ID_BUFFER);
     JS_SetPrototype(ctx, ret, proto);
     JS_FreeValue(ctx, proto);
 
@@ -2494,7 +2491,7 @@ qjs_new_uint8_array(JSContext *ctx, int argc, JSValueConst *argv)
 #else
     JSValue ctor;
 
-    ctor = JS_GetClassProto(ctx, qjs_uint8_array_ctor_id);
+    ctor = JS_GetClassProto(ctx, QJS_CORE_CLASS_ID_UINT8_ARRAY_CTOR);
     ret = JS_CallConstructor(ctx, ctor, argc, argv);
     JS_FreeValue(ctx, ctor);
 #endif
@@ -2511,8 +2508,8 @@ qjs_buffer_builtin_init(JSContext *ctx)
     JSValue    global_obj, buffer, proto, ctor, ta, ta_proto, symbol, species;
     JSClassID  u8_ta_class_id;
 
-    JS_NewClassID(&qjs_buffer_class_id);
-    JS_NewClass(JS_GetRuntime(ctx), qjs_buffer_class_id, &qjs_buffer_class);
+    JS_NewClass(JS_GetRuntime(ctx), QJS_CORE_CLASS_ID_BUFFER,
+                &qjs_buffer_class);
 
     global_obj = JS_GetGlobalObject(ctx);
 
@@ -2528,10 +2525,10 @@ qjs_buffer_builtin_init(JSContext *ctx)
      * We use JS_SetClassProto()/JS_GetClassProto() as a key-value store
      * for fast value query by class ID without querying the global object.
      */
-    JS_NewClassID(&qjs_uint8_array_ctor_id);
-    JS_NewClass(JS_GetRuntime(ctx), qjs_uint8_array_ctor_id,
+    JS_NewClass(JS_GetRuntime(ctx), QJS_CORE_CLASS_ID_UINT8_ARRAY_CTOR,
                 &qjs_uint8_array_ctor_class);
-    JS_SetClassProto(ctx, qjs_uint8_array_ctor_id, JS_DupValue(ctx, ctor));
+    JS_SetClassProto(ctx, QJS_CORE_CLASS_ID_UINT8_ARRAY_CTOR,
+                     JS_DupValue(ctx, ctor));
 #endif
 
     ta = JS_CallConstructor(ctx, ctor, 0, NULL);
@@ -2543,7 +2540,7 @@ qjs_buffer_builtin_init(JSContext *ctx)
     JS_SetPrototype(ctx, proto, ta_proto);
     JS_FreeValue(ctx, ta_proto);
 
-    JS_SetClassProto(ctx, qjs_buffer_class_id, proto);
+    JS_SetClassProto(ctx, QJS_CORE_CLASS_ID_BUFFER, proto);
 
     buffer = JS_NewCFunction2(ctx, qjs_buffer, "Buffer", 3,
                               JS_CFUNC_constructor, 0);


### PR DESCRIPTION
Two main patches:

1) Modules: introduced engine API. - adapts the modules code to allow multiple JS engines.

2) Modules: introduced QuickJS engine. 
   "js_engine" directive is introduced which sets JavaScript engine.
    When the module is built with QuickJS library "js_engine qjs;" sets
    QuickJS engine for the current block. By default njs engine is used.
    
    For example,
    
    nginx.conf:
    
        location /a {
            js_engine qjs;
            # will be handled by QuickJS
            js_content main.handler;
        }
    
        location /b {
            # will be handled by njs
            js_content main.handler;
        }
    
    QuickJS engine implements drop-in replacement for nginx/njs objects
    with the following exceptions:
    
        * nginx module API to be added later: ngx.fetch(), ngx.shared.dict.
        * Built-in modules to be added later: fs, crypto, WebCrypto, xml.
        * NJS specific API: njs.dump(), njs.on(), console.dump().
        * js_preload_object directive.
        
 Use `TEST_NGINX_GLOBALS_HTTP='js_engine qjs;' TEST_NGINX_GLOBALS_STREAM='js_engine qjs;'` when running njs tests to test QuickJS module. 
 For example:  
 to run tests with njs engine:  `TEST_NGINX_BINARY=/path/to/nginx/binary prove -I /path/to/nginx-tests/lib/ nginx/t/`
 to run  tests with QuickJS engine:  `TEST_NGINX_GLOBALS_HTTP='js_engine qjs;' TEST_NGINX_GLOBALS_STREAM='js_engine qjs;' TEST_NGINX_BINARY=/path/to/nginx/binary prove -I /path/to/nginx-tests/lib/ nginx/t/`