### PR TITLE
Configure: accept spaces in PATH.

### DIFF
--- a/auto/expect
+++ b/auto/expect
@@ -21,9 +21,9 @@ if [ $njs_found = yes -a $NJS_HAVE_READLINE = YES ]; then
     cat << END >> $NJS_MAKEFILE
 
 shell_test_njs:	njs test/shell_test.exp
-	PATH=$NJS_BUILD_DIR:\$(PATH) LANG=C.UTF-8 TERM=screen \
+	PATH="$NJS_BUILD_DIR:\$(PATH)" LANG=C.UTF-8 TERM=screen \
     expect -f test/shell_test.exp
-	PATH=$NJS_BUILD_DIR:\$(PATH) LANG=C.UTF-8 TERM=screen \
+	PATH="$NJS_BUILD_DIR:\$(PATH)" LANG=C.UTF-8 TERM=screen \
     expect -f test/shell_test_njs.exp
 END
 
@@ -33,7 +33,7 @@ if [ $NJS_HAVE_QUICKJS = YES ]; then
 shell_test:	shell_test_njs shell_test_quickjs
 
 shell_test_quickjs:	njs test/shell_test.exp
-	PATH=$NJS_BUILD_DIR:\$(PATH) LANG=C.UTF-8 TERM=screen NJS_ENGINE=QuickJS \
+	PATH="$NJS_BUILD_DIR:\$(PATH)" LANG=C.UTF-8 TERM=screen NJS_ENGINE=QuickJS \
     expect -f test/shell_test.exp
 END
 


### PR DESCRIPTION
### Proposed changes

Configure: allow spaces in PATH.
This is useful for WSL (Windows Subsystem for Linux) where PATH by default contains spaces. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [X] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
