### PR TITLE
Atomic keys introduction for strings, symbols, small numbers.

### DIFF
--- a/src/njs_buffer.c
+++ b/src/njs_buffer.c
@@ -337,6 +337,9 @@ next:
 }
 
 
+static const njs_str_t  str_buffer = njs_str("Buffer");
+
+
 static njs_int_t
 njs_buffer_from_object(njs_vm_t *vm, njs_value_t *value, njs_value_t *retval)
 {
@@ -348,9 +351,6 @@ njs_buffer_from_object(njs_vm_t *vm, njs_value_t *value, njs_value_t *retval)
     njs_int_t          ret;
     njs_value_t        val, data, length;
     njs_typed_array_t  *buffer;
-
-    static const njs_value_t  string_length = njs_string("length");
-    static const njs_str_t  str_buffer = njs_str("Buffer");
 
 next:
 
@@ -2358,6 +2358,9 @@ njs_buffer_prototype_swap(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 }
 
 
+static const njs_value_t  string_buffer = njs_string("Buffer");
+
+
 static njs_int_t
 njs_buffer_prototype_to_json(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_index_t unused, njs_value_t *retval)
@@ -2370,8 +2373,6 @@ njs_buffer_prototype_to_json(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_object_t        *obj;
     njs_typed_array_t   *ta;
     njs_array_buffer_t  *buffer;
-
-    static const njs_value_t  string_buffer = njs_string("Buffer");
 
     ta = njs_buffer_slot(vm, njs_argument(args, 0), "this");
     if (njs_slow_path(ta == NULL)) {
@@ -2660,7 +2661,7 @@ static const njs_object_prop_t  njs_buffer_constructor_properties[] =
 
     NJS_DECLARE_PROP_NATIVE("allocUnsafe", njs_buffer_alloc_safe, 0, 0),
 
-    NJS_DECLARE_PROP_LNATIVE("allocUnsafeSlow", njs_buffer_alloc_safe, 1, 0),
+    NJS_DECLARE_PROP_NATIVE("allocUnsafeSlow", njs_buffer_alloc_safe, 1, 0),
 
     NJS_DECLARE_PROP_NATIVE("byteLength", njs_buffer_byte_length, 1, 0),
 
@@ -2695,9 +2696,9 @@ static const njs_object_prop_t  njs_buffer_constants_properties[] =
     NJS_DECLARE_PROP_VALUE("MAX_LENGTH", njs_value(NJS_NUMBER, 1, INT32_MAX),
                            NJS_OBJECT_PROP_VALUE_E),
 
-    NJS_DECLARE_PROP_LVALUE("MAX_STRING_LENGTH",
-                            njs_value(NJS_NUMBER, 1, NJS_STRING_MAX_LENGTH),
-                            NJS_OBJECT_PROP_VALUE_E),
+    NJS_DECLARE_PROP_VALUE("MAX_STRING_LENGTH",
+                           njs_value(NJS_NUMBER, 1, NJS_STRING_MAX_LENGTH),
+                           NJS_OBJECT_PROP_VALUE_E),
 };
 
 

--- a/src/njs_date.c
+++ b/src/njs_date.c
@@ -1439,6 +1439,9 @@ done:
 }
 
 
+static const njs_value_t  to_iso_string = njs_string("toISOString");
+
+
 static njs_int_t
 njs_date_prototype_to_json(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_index_t unused, njs_value_t *retval)
@@ -1446,8 +1449,6 @@ njs_date_prototype_to_json(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_int_t           ret;
     njs_value_t         value;
     njs_lvlhsh_query_t  lhq;
-
-    static const njs_value_t  to_iso_string = njs_string("toISOString");
 
     if (njs_is_object(njs_argument(args, 0))) {
         njs_object_property_init(&lhq, &to_iso_string, NJS_TO_ISO_STRING_HASH);
@@ -1494,13 +1495,13 @@ static const njs_object_prop_t  njs_date_prototype_properties[] =
     NJS_DECLARE_PROP_NATIVE("toLocaleString", njs_date_prototype_to_string, 0,
                             NJS_DATE_FMT_TO_STRING),
 
-    NJS_DECLARE_PROP_LNATIVE("toLocaleDateString",
-                             njs_date_prototype_to_string, 0,
-                             NJS_DATE_FMT_TO_DATE_STRING),
+    NJS_DECLARE_PROP_NATIVE("toLocaleDateString",
+                            njs_date_prototype_to_string, 0,
+                            NJS_DATE_FMT_TO_DATE_STRING),
 
-    NJS_DECLARE_PROP_LNATIVE("toLocaleTimeString",
-                             njs_date_prototype_to_string, 0,
-                             NJS_DATE_FMT_TO_TIME_STRING),
+    NJS_DECLARE_PROP_NATIVE("toLocaleTimeString",
+                            njs_date_prototype_to_string, 0,
+                            NJS_DATE_FMT_TO_TIME_STRING),
 
     NJS_DECLARE_PROP_NATIVE("toUTCString",
                             njs_date_prototype_to_string, 0,
@@ -1570,26 +1571,26 @@ static const njs_object_prop_t  njs_date_prototype_properties[] =
                             njs_date_prototype_get_field, 0,
                             njs_date_magic(NJS_DATE_SEC, 0)),
 
-    NJS_DECLARE_PROP_LNATIVE("getMilliseconds",
-                             njs_date_prototype_get_field, 0,
-                             njs_date_magic(NJS_DATE_MSEC, 1)),
+    NJS_DECLARE_PROP_NATIVE("getMilliseconds",
+                            njs_date_prototype_get_field, 0,
+                            njs_date_magic(NJS_DATE_MSEC, 1)),
 
-    NJS_DECLARE_PROP_LNATIVE("getUTCMilliseconds",
-                             njs_date_prototype_get_field, 0,
-                             njs_date_magic(NJS_DATE_MSEC, 0)),
+    NJS_DECLARE_PROP_NATIVE("getUTCMilliseconds",
+                            njs_date_prototype_get_field, 0,
+                            njs_date_magic(NJS_DATE_MSEC, 0)),
 
-    NJS_DECLARE_PROP_LNATIVE("getTimezoneOffset",
-                             njs_date_prototype_get_timezone_offset, 0, 0),
+    NJS_DECLARE_PROP_NATIVE("getTimezoneOffset",
+                            njs_date_prototype_get_timezone_offset, 0, 0),
 
     NJS_DECLARE_PROP_NATIVE("setTime", njs_date_prototype_set_time, 1, 0),
 
-    NJS_DECLARE_PROP_LNATIVE("setMilliseconds",
-                             njs_date_prototype_set_fields, 1,
-                             njs_date_magic2(NJS_DATE_MSEC, 1, 1)),
+    NJS_DECLARE_PROP_NATIVE("setMilliseconds",
+                            njs_date_prototype_set_fields, 1,
+                            njs_date_magic2(NJS_DATE_MSEC, 1, 1)),
 
-    NJS_DECLARE_PROP_LNATIVE("setUTCMilliseconds",
-                             njs_date_prototype_set_fields, 1,
-                             njs_date_magic2(NJS_DATE_MSEC, 1, 0)),
+    NJS_DECLARE_PROP_NATIVE("setUTCMilliseconds",
+                            njs_date_prototype_set_fields, 1,
+                            njs_date_magic2(NJS_DATE_MSEC, 1, 0)),
 
     NJS_DECLARE_PROP_NATIVE("setSeconds",
                             njs_date_prototype_set_fields, 2,

--- a/src/njs_encoding.c
+++ b/src/njs_encoding.c
@@ -154,6 +154,10 @@ njs_text_encoder_encode_utf8(njs_vm_t *vm, njs_string_prop_t *prop,
 }
 
 
+static const njs_value_t  read_str = njs_string("read");
+static const njs_value_t  written_str = njs_string("written");
+
+
 static njs_int_t
 njs_text_encoder_encode_into(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_index_t unused, njs_value_t *retval)
@@ -167,9 +171,6 @@ njs_text_encoder_encode_into(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     const u_char          *start, *end;
     njs_typed_array_t     *array;
     njs_unicode_decode_t  ctx;
-
-    static const njs_value_t  read_str = njs_string("read");
-    static const njs_value_t  written_str = njs_string("written");
 
     this = njs_argument(args, 0);
     input = njs_arg(args, nargs, 1);
@@ -357,15 +358,16 @@ njs_text_decoder_arg_encoding(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 }
 
 
+static const njs_value_t  fatal_str = njs_string("fatal");
+static const njs_value_t  ignore_bom_str = njs_string("ignoreBOM");
+
+
 static njs_int_t
 njs_text_decoder_arg_options(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_encoding_decode_t *data)
 {
     njs_int_t    ret;
     njs_value_t  retval, *value;
-
-    static const njs_value_t  fatal_str = njs_string("fatal");
-    static const njs_value_t  ignore_bom_str = njs_string("ignoreBOM");
 
     if (nargs < 3) {
         data->fatal = 0;
@@ -400,13 +402,14 @@ njs_text_decoder_arg_options(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 }
 
 
+static const njs_value_t  utf8_str = njs_string("utf-8");
+
+
 static njs_int_t
 njs_text_decoder_encoding(njs_vm_t *vm, njs_object_prop_t *prop,
     njs_value_t *value, njs_value_t *setval, njs_value_t *retval)
 {
     njs_encoding_decode_t  *data;
-
-    static const njs_value_t  utf8_str = njs_string("utf-8");
 
     if (njs_slow_path(!njs_is_object_data(value, NJS_DATA_TAG_TEXT_DECODER))) {
         njs_set_undefined(retval);
@@ -467,6 +470,9 @@ njs_text_decoder_ignore_bom(njs_vm_t *vm, njs_object_prop_t *prop,
 }
 
 
+static const njs_value_t  stream_str = njs_string("stream");
+
+
 static njs_int_t
 njs_text_decoder_decode(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_index_t unused, njs_value_t *retval)
@@ -482,8 +488,6 @@ njs_text_decoder_decode(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_encoding_decode_t     *data;
     const njs_typed_array_t   *array;
     const njs_array_buffer_t  *buffer;
-
-    static const njs_value_t  stream_str = njs_string("stream");
 
     start = NULL;
     end = NULL;

--- a/src/njs_error.c
+++ b/src/njs_error.c
@@ -577,6 +577,10 @@ njs_error_prototype_value_of(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 }
 
 
+static const njs_value_t  string_message = njs_string("message");
+static const njs_value_t  default_name = njs_string("Error");
+
+
 static njs_int_t
 njs_error_to_string2(njs_vm_t *vm, njs_value_t *retval,
     const njs_value_t *error, njs_bool_t want_stack)
@@ -587,9 +591,6 @@ njs_error_to_string2(njs_vm_t *vm, njs_value_t *retval,
     njs_value_t        value1, value2;
     njs_value_t        *name_value, *message_value;
     njs_string_prop_t  name, message;
-
-    static const njs_value_t  string_message = njs_string("message");
-    static const njs_value_t  default_name = njs_string("Error");
 
     njs_assert(njs_is_object(error));
 
@@ -763,12 +764,13 @@ const njs_object_type_init_t  njs_eval_error_type_init = {
 };
 
 
+static const njs_value_t name = njs_string("MemoryError");
+
+
 static njs_int_t
 njs_internal_error_prototype_to_string(njs_vm_t *vm, njs_value_t *args,
     njs_uint_t nargs, njs_index_t unused, njs_value_t *retval)
 {
-    static const njs_value_t name = njs_string("MemoryError");
-
     if (nargs >= 1 && njs_is_object(&args[0])) {
         /* MemoryError is a nonextensible internal error. */
         if (!njs_object(&args[0])->extensible) {

--- a/src/njs_function.c
+++ b/src/njs_function.c
@@ -251,8 +251,6 @@ njs_function_arguments_object_init(njs_vm_t *vm, njs_native_frame_t *frame)
     njs_value_t   value, length;
     njs_object_t  *arguments;
 
-    static const njs_value_t  string_length = njs_string("length");
-
     arguments = njs_object_alloc(vm);
     if (njs_slow_path(arguments == NULL)) {
         return NJS_ERROR;
@@ -912,9 +910,7 @@ njs_function_property_prototype_set(njs_vm_t *vm, njs_lvlhsh_t *hash,
     njs_object_prop_t   *prop;
     njs_lvlhsh_query_t  lhq;
 
-    const njs_value_t  proto_string = njs_string("prototype");
-
-    prop = njs_object_prop_alloc(vm, &proto_string, prototype, 0);
+    prop = njs_object_prop_alloc(vm, &njs_string_prototype, prototype, 0);
     if (njs_slow_path(prop == NULL)) {
         return NULL;
     }

--- a/src/njs_iterator.c
+++ b/src/njs_iterator.c
@@ -358,8 +358,10 @@ njs_object_iterate(njs_vm_t *vm, njs_iterator_args_t *args,
             /* ASCII string. */
 
             for (i = from; i < to; i++) {
-                /* This cannot fail. */
-                (void) njs_string_new(vm, &character, p + i, 1, 1);
+                ret = njs_string_new(vm, &character, p + i, 1, 1);
+                if (njs_slow_path(ret != NJS_OK)) {
+                    return NJS_ERROR;
+                }
 
                 ret = handler(vm, args, &character, i, retval);
                 if (njs_slow_path(ret != NJS_OK)) {
@@ -377,8 +379,10 @@ njs_object_iterate(njs_vm_t *vm, njs_iterator_args_t *args,
             for (i = from; i < to; i++) {
                 pos = njs_utf8_next(p, end);
 
-                /* This cannot fail. */
-                (void) njs_string_new(vm, &character, p, pos - p, 1);
+                ret = njs_string_new(vm, &character, p, pos - p, 1);
+                if (njs_slow_path(ret != NJS_OK)) {
+                    return NJS_ERROR;
+                }
 
                 ret = handler(vm, args, &character, i, retval);
                 if (njs_slow_path(ret != NJS_OK)) {
@@ -513,8 +517,10 @@ njs_object_iterate_reverse(njs_vm_t *vm, njs_iterator_args_t *args,
             i = from + 1;
 
             while (i-- > to) {
-                /* This cannot fail. */
-                (void) njs_string_new(vm, &character, p, 1, 1);
+                ret = njs_string_new(vm, &character, p, 1, 1);
+                if (njs_slow_path(ret != NJS_OK)) {
+                    return NJS_ERROR;
+                }
 
                 ret = handler(vm, args, &character, i, retval);
                 if (njs_slow_path(ret != NJS_OK)) {
@@ -542,8 +548,10 @@ njs_object_iterate_reverse(njs_vm_t *vm, njs_iterator_args_t *args,
             while (i-- > to) {
                 pos = njs_utf8_prev(p, string_prop.start);
 
-                /* This cannot fail. */
-                (void) njs_string_new(vm, &character, pos, p - pos , 1);
+                ret = njs_string_new(vm, &character, pos, p - pos , 1);
+                if (njs_slow_path(ret != NJS_OK)) {
+                    return NJS_ERROR;
+                }
 
                 ret = handler(vm, args, &character, i, retval);
                 if (njs_slow_path(ret != NJS_OK)) {

--- a/src/njs_main.h
+++ b/src/njs_main.h
@@ -45,6 +45,7 @@
 #include <njs_vm.h>
 #include <njs_object_prop_declare.h>
 #include <njs_error.h>
+#include <njs_string.h>
 #include <njs_number.h>
 #include <njs_value_conversion.h>
 #include <njs_vmcode.h>
@@ -56,7 +57,6 @@
 
 #include <njs_boolean.h>
 #include <njs_symbol.h>
-#include <njs_string.h>
 #include <njs_object.h>
 #include <njs_object_hash.h>
 #include <njs_array.h>

--- a/src/njs_number.c
+++ b/src/njs_number.c
@@ -252,19 +252,7 @@ njs_int_t
 njs_int64_to_string(njs_vm_t *vm, njs_value_t *value, int64_t i64)
 {
     size_t  size;
-    u_char  *dst, *p;
     u_char  buf[128];
-
-    if (njs_fast_path(i64 >= 0 && i64 < 0x3fffffffffffLL)) {
-        /* Fits to short_string. */
-        dst = njs_string_short_start(value);
-
-        p = njs_sprintf(dst, dst + NJS_STRING_SHORT, "%L", i64);
-
-        njs_string_short_set(value, p - dst, p - dst);
-
-        return NJS_OK;
-    }
 
     size = njs_dtoa(i64, (char *) buf);
 
@@ -449,11 +437,11 @@ static const njs_object_prop_t  njs_number_constructor_properties[] =
 
     NJS_DECLARE_PROP_VALUE("EPSILON", njs_value(NJS_NUMBER, 1, DBL_EPSILON), 0),
 
-    NJS_DECLARE_PROP_LVALUE("MAX_SAFE_INTEGER",
-                            njs_value(NJS_NUMBER, 1, NJS_MAX_SAFE_INTEGER), 0),
+    NJS_DECLARE_PROP_VALUE("MAX_SAFE_INTEGER",
+                           njs_value(NJS_NUMBER, 1, NJS_MAX_SAFE_INTEGER), 0),
 
-    NJS_DECLARE_PROP_LVALUE("MIN_SAFE_INTEGER",
-                            njs_value(NJS_NUMBER, 1, -NJS_MAX_SAFE_INTEGER), 0),
+    NJS_DECLARE_PROP_VALUE("MIN_SAFE_INTEGER",
+                           njs_value(NJS_NUMBER, 1, -NJS_MAX_SAFE_INTEGER), 0),
 
     NJS_DECLARE_PROP_VALUE("MAX_VALUE", njs_value(NJS_NUMBER, 1, DBL_MAX), 0),
 
@@ -461,11 +449,11 @@ static const njs_object_prop_t  njs_number_constructor_properties[] =
 
     NJS_DECLARE_PROP_VALUE("NaN", njs_value(NJS_NUMBER, 0, NAN), 0),
 
-    NJS_DECLARE_PROP_LVALUE("POSITIVE_INFINITY",
-                            njs_value(NJS_NUMBER, 1, INFINITY), 0),
+    NJS_DECLARE_PROP_VALUE("POSITIVE_INFINITY",
+                           njs_value(NJS_NUMBER, 1, INFINITY), 0),
 
-    NJS_DECLARE_PROP_LVALUE("NEGATIVE_INFINITY",
-                            njs_value(NJS_NUMBER, 1, -INFINITY), 0),
+    NJS_DECLARE_PROP_VALUE("NEGATIVE_INFINITY",
+                           njs_value(NJS_NUMBER, 1, -INFINITY), 0),
 
     NJS_DECLARE_PROP_NATIVE("isFinite", njs_number_is_finite, 1, 0),
 

--- a/src/njs_number.h
+++ b/src/njs_number.h
@@ -168,15 +168,22 @@ njs_char_to_hex(u_char c)
 }
 
 
-njs_inline void
-njs_uint32_to_string(njs_value_t *value, uint32_t u32)
+njs_inline njs_int_t
+njs_uint32_to_string(njs_vm_t *vm, njs_value_t *value, uint32_t u32)
 {
-    u_char  *dst, *p;
+    size_t  size;
+    u_char  *p;
 
-    dst = njs_string_short_start(value);
-    p = njs_sprintf(dst, dst + NJS_STRING_SHORT, "%uD", u32);
+    p = njs_string_alloc(vm, value, 10, 10);
+    if (njs_slow_path(p == NULL)) {
+        return NJS_ERROR;
+    }
 
-    njs_string_short_set(value, p - dst, p - dst);
+    size = njs_sprintf(p, p + 10, "%uD", u32) - p;
+    value->string.data->length = size;
+    value->string.data->size = size;
+
+    return NJS_OK;
 }
 
 

--- a/src/njs_object.h
+++ b/src/njs_object.h
@@ -290,12 +290,12 @@ njs_value_create_data_prop_i64(njs_vm_t *vm, njs_value_t *value, int64_t index,
 }
 
 
+static const njs_value_t string_length = njs_string("length");
+
 njs_inline njs_int_t
 njs_object_length_set(njs_vm_t *vm, njs_value_t *value, int64_t length)
 {
     njs_value_t  index;
-
-    static const njs_value_t  string_length = njs_string("length");
 
     njs_value_number_set(&index, length);
 

--- a/src/njs_object_prop.c
+++ b/src/njs_object_prop.c
@@ -719,6 +719,9 @@ njs_prop_private_copy(njs_vm_t *vm, njs_property_query_t *pq,
 }
 
 
+static const njs_value_t  get_string = njs_string("get");
+
+
 static njs_object_prop_t *
 njs_descriptor_prop(njs_vm_t *vm, const njs_value_t *name,
     const njs_value_t *desc)
@@ -730,8 +733,6 @@ njs_descriptor_prop(njs_vm_t *vm, const njs_value_t *name,
     njs_function_t      *getter, *setter;
     njs_object_prop_t   *prop;
     njs_lvlhsh_query_t  lhq;
-
-    static const njs_value_t  get_string = njs_string("get");
 
     if (!njs_is_object(desc)) {
         njs_type_error(vm, "property descriptor must be an object");

--- a/src/njs_object_prop_declare.h
+++ b/src/njs_object_prop_declare.h
@@ -18,25 +18,8 @@
     }
 
 
-#define NJS_DECLARE_PROP_LVALUE(_name, _v, _fl)                               \
-    {                                                                         \
-        .type = NJS_PROPERTY,                                                 \
-        .name = njs_long_string(_name),                                       \
-        .u.value = _v,                                                        \
-        .enumerable = !!(_fl & NJS_OBJECT_PROP_ENUMERABLE),                   \
-        .configurable = !!(_fl & NJS_OBJECT_PROP_CONFIGURABLE),               \
-        .writable = !!(_fl & NJS_OBJECT_PROP_WRITABLE),                       \
-    }
-
-
 #define NJS_DECLARE_PROP_NATIVE(_name, _native, _nargs, _magic)               \
     NJS_DECLARE_PROP_VALUE(_name,                                             \
-                           njs_native_function2(_native, _nargs, _magic),     \
-                           NJS_OBJECT_PROP_VALUE_CW)
-
-
-#define NJS_DECLARE_PROP_LNATIVE(_name, _native, _nargs, _magic)              \
-    NJS_DECLARE_PROP_LVALUE(_name,                                            \
                            njs_native_function2(_native, _nargs, _magic),     \
                            NJS_OBJECT_PROP_VALUE_CW)
 

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -1218,6 +1218,9 @@ done:
 }
 
 
+static const njs_value_t  string_message = njs_string("message");
+
+
 static njs_int_t
 njs_parser_regexp_literal(njs_parser_t *parser, njs_lexer_token_t *token,
     njs_queue_link_t *current)
@@ -1229,8 +1232,6 @@ njs_parser_regexp_literal(njs_parser_t *parser, njs_lexer_token_t *token,
     njs_value_t           *value, retval;
     njs_regex_flags_t     flags;
     njs_regexp_pattern_t  *pattern;
-
-    static const njs_value_t  string_message = njs_string("message");
 
     value = &parser->node->u.value;
     lexer = parser->lexer;
@@ -8725,7 +8726,7 @@ njs_parser_string_create(njs_vm_t *vm, njs_lexer_token_t *token,
     njs_decode_utf8(&dst, &token->text);
 
     if (length > NJS_STRING_MAP_STRIDE && dst.length != length) {
-        njs_string_utf8_offset_map_init(value->long_string.data->start,
+        njs_string_utf8_offset_map_init(value->string.data->start,
                                         dst.length);
     }
 
@@ -9210,6 +9211,10 @@ njs_parser_unexpected_token(njs_vm_t *vm, njs_parser_t *parser,
 }
 
 
+static const njs_value_t  file_name = njs_string("fileName");
+static const njs_value_t  line_number = njs_string("lineNumber");
+
+
 static void
 njs_parser_error(njs_vm_t *vm, njs_object_type_t type, njs_str_t *file,
     uint32_t line, const char *fmt, va_list args)
@@ -9219,9 +9224,6 @@ njs_parser_error(njs_vm_t *vm, njs_object_type_t type, njs_str_t *file,
     u_char       *p, *end;
     njs_int_t    ret;
     njs_value_t  value, error;
-
-    static const njs_value_t  file_name = njs_string("fileName");
-    static const njs_value_t  line_number = njs_string("lineNumber");
 
     if (njs_slow_path(vm->top_frame == NULL)) {
         njs_vm_runtime_init(vm);

--- a/src/njs_promise.c
+++ b/src/njs_promise.c
@@ -107,7 +107,7 @@ static njs_int_t njs_promise_perform_race_handler(njs_vm_t *vm,
 
 static const njs_value_t  string_resolve = njs_string("resolve");
 static const njs_value_t  string_any_rejected =
-                                 njs_long_string("All promises were rejected");
+                                      njs_string("All promises were rejected");
 
 
 static njs_promise_t *
@@ -391,14 +391,12 @@ njs_promise_value_constructor(njs_vm_t *vm, njs_value_t *value,
 {
     njs_int_t  ret;
 
-    static const njs_value_t  string_constructor = njs_string("constructor");
-
     if (njs_is_function(value)) {
         *dst = *value;
         return NJS_OK;
     }
 
-    ret = njs_value_property(vm, value, njs_value_arg(&string_constructor),
+    ret = njs_value_property(vm, value, njs_value_arg(&njs_string_ctor),
                              dst);
     if (njs_slow_path(ret == NJS_ERROR)) {
         return ret;
@@ -545,14 +543,15 @@ njs_promise_reject(njs_vm_t *vm, njs_promise_t *promise, njs_value_t *reason)
 }
 
 
+static const njs_value_t  string_then = njs_string("then");
+
+
 static njs_int_t
 njs_promise_invoke_then(njs_vm_t *vm, njs_value_t *promise, njs_value_t *args,
     njs_int_t nargs, njs_value_t *retval)
 {
     njs_int_t    ret;
     njs_value_t  function;
-
-    static const njs_value_t  string_then = njs_string("then");
 
     ret = njs_value_property(vm, promise, njs_value_arg(&string_then),
                              &function);
@@ -587,8 +586,6 @@ njs_promise_resolve_function(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_function_t         *function;
     njs_native_frame_t     *active_frame;
     njs_promise_context_t  *context;
-
-    static const njs_value_t  string_then = njs_string("then");
 
     active_frame = vm->top_frame;
     context = active_frame->function->context;
@@ -701,10 +698,8 @@ njs_promise_resolve(njs_vm_t *vm, njs_value_t *constructor, njs_value_t *x)
     njs_value_t               value;
     njs_promise_capability_t  *capability;
 
-    static const njs_value_t  string_constructor = njs_string("constructor");
-
     if (njs_is_promise(x)) {
-        ret = njs_value_property(vm, x, njs_value_arg(&string_constructor),
+        ret = njs_value_property(vm, x, njs_value_arg(&njs_string_ctor),
                                  &value);
         if (njs_slow_path(ret == NJS_ERROR)) {
             return NULL;
@@ -1470,6 +1465,13 @@ njs_promise_perform_all_settled_handler(njs_vm_t *vm, njs_iterator_args_t *args,
 }
 
 
+static const njs_value_t  string_status = njs_string("status");
+static const njs_value_t  string_fulfilled = njs_string("fulfilled");
+static const njs_value_t  string_value = njs_string("value");
+static const njs_value_t  string_rejected = njs_string("rejected");
+static const njs_value_t  string_reason = njs_string("reason");
+
+
 static njs_int_t
 njs_promise_all_settled_element_functions(njs_vm_t *vm,
     njs_value_t *args, njs_uint_t nargs, njs_index_t rejected,
@@ -1480,12 +1482,6 @@ njs_promise_all_settled_element_functions(njs_vm_t *vm,
     njs_object_t               *obj;
     const njs_value_t          *status, *set;
     njs_promise_all_context_t  *context;
-
-    static const njs_value_t  string_status = njs_string("status");
-    static const njs_value_t  string_fulfilled = njs_string("fulfilled");
-    static const njs_value_t  string_value = njs_string("value");
-    static const njs_value_t  string_rejected = njs_string("rejected");
-    static const njs_value_t  string_reason = njs_string("reason");
 
     context = vm->top_frame->function->context;
 

--- a/src/njs_regexp.c
+++ b/src/njs_regexp.c
@@ -513,7 +513,7 @@ njs_regexp_alloc(njs_vm_t *vm, njs_regexp_pattern_t *pattern)
         regexp->object.error_data = 0;
         njs_set_number(&regexp->last_index, 0);
         regexp->pattern = pattern;
-        njs_string_short_set(&regexp->string, 0, 0);
+        regexp->string = njs_string_empty;
         return regexp;
     }
 
@@ -548,6 +548,12 @@ njs_regexp_prototype_last_index(njs_vm_t *vm, njs_object_prop_t *unused,
 }
 
 
+static const njs_value_t  string_global = njs_string("global");
+static const njs_value_t  string_ignore_case = njs_string("ignoreCase");
+static const njs_value_t  string_multiline = njs_string("multiline");
+static const njs_value_t  string_sticky = njs_string("sticky");
+
+
 static njs_int_t
 njs_regexp_prototype_flags(njs_vm_t *vm, njs_value_t *args,
     njs_uint_t nargs, njs_index_t unused, njs_value_t *retval)
@@ -556,11 +562,6 @@ njs_regexp_prototype_flags(njs_vm_t *vm, njs_value_t *args,
     njs_int_t    ret;
     njs_value_t  *this, value;
     u_char       dst[4];
-
-    static const njs_value_t  string_global = njs_string("global");
-    static const njs_value_t  string_ignore_case = njs_string("ignoreCase");
-    static const njs_value_t  string_multiline = njs_string("multiline");
-    static const njs_value_t  string_sticky = njs_string("sticky");
 
     this = njs_argument(args, 0);
     if (njs_slow_path(!njs_is_object(this))) {
@@ -698,6 +699,10 @@ njs_regexp_prototype_source(njs_vm_t *vm, njs_value_t *args,
 }
 
 
+static const njs_value_t  string_source = njs_string("source");
+static const njs_value_t  string_flags = njs_string("flags");
+
+
 static njs_int_t
 njs_regexp_prototype_to_string(njs_vm_t *vm, njs_value_t *args,
     njs_uint_t nargs, njs_index_t unused, njs_value_t *retval)
@@ -707,9 +712,6 @@ njs_regexp_prototype_to_string(njs_vm_t *vm, njs_value_t *args,
     njs_int_t          ret;
     njs_value_t        *r, source, flags;
     njs_string_prop_t  source_string, flags_string;
-
-    static const njs_value_t  string_source = njs_string("source");
-    static const njs_value_t  string_flags = njs_string("flags");
 
     r = njs_argument(args, 0);
 
@@ -1008,6 +1010,11 @@ static njs_exotic_slots_t njs_regexp_prototype_exotic_slots = {
 };
 
 
+static const njs_value_t  string_index = njs_string("index");
+static const njs_value_t  string_input = njs_string("input");
+static const njs_value_t  string_groups = njs_string("groups");
+
+
 static njs_array_t *
 njs_regexp_exec_result(njs_vm_t *vm, njs_value_t *r, njs_utf8_t utf8,
     njs_string_prop_t *string, njs_regex_match_data_t *match_data)
@@ -1026,10 +1033,6 @@ njs_regexp_exec_result(njs_vm_t *vm, njs_value_t *r, njs_utf8_t utf8,
     njs_regexp_group_t    *group;
     njs_lvlhsh_query_t    lhq;
     njs_regexp_pattern_t  *pattern;
-
-    static const njs_value_t  string_index = njs_string("index");
-    static const njs_value_t  string_input = njs_string("input");
-    static const njs_value_t  string_groups = njs_string("groups");
 
     regexp = njs_regexp(r);
     pattern = regexp->pattern;
@@ -1185,8 +1188,8 @@ njs_regexp_exec_result_free(njs_vm_t *vm, njs_array_t *result)
         start = result->start;
 
         for (n = 0; n < result->length; n++) {
-            if (start[n].short_string.size == NJS_STRING_LONG) {
-                njs_mp_free(vm->mem_pool, start[n].long_string.data);
+            if (start[n].type == NJS_STRING) {
+                njs_mp_free(vm->mem_pool, start[n].string.data);
             }
         }
     }
@@ -1249,6 +1252,9 @@ njs_regexp_prototype_exec(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 }
 
 
+static const njs_value_t  string_exec = njs_string("exec");
+
+
 static njs_int_t
 njs_regexp_exec(njs_vm_t *vm, njs_value_t *r, njs_value_t *s, unsigned flags,
     njs_value_t *retval)
@@ -1256,8 +1262,6 @@ njs_regexp_exec(njs_vm_t *vm, njs_value_t *r, njs_value_t *s, unsigned flags,
     njs_int_t    ret;
     njs_value_t  exec;
     njs_value_t  arguments[2];
-
-    static const njs_value_t  string_exec = njs_string("exec");
 
     ret = njs_value_property(vm, r, njs_value_arg(&string_exec), &exec);
     if (njs_slow_path(ret == NJS_ERROR)) {
@@ -1323,10 +1327,6 @@ njs_regexp_prototype_symbol_replace(njs_vm_t *vm, njs_value_t *args,
     njs_value_t        s_lvalue, r_lvalue, value, matched, groups;
     njs_function_t     *func_replace;
     njs_string_prop_t  s;
-
-    static const njs_value_t  string_global = njs_string("global");
-    static const njs_value_t  string_groups = njs_string("groups");
-    static const njs_value_t  string_index = njs_string("index");
 
     rx = njs_argument(args, 0);
 
@@ -1597,6 +1597,9 @@ exception:
 }
 
 
+static const njs_value_t  string_lindex = njs_string("lastIndex");
+
+
 static njs_int_t
 njs_regexp_prototype_symbol_split(njs_vm_t *vm, njs_value_t *args,
     njs_uint_t nargs, njs_index_t unused, njs_value_t *retval)
@@ -1615,9 +1618,6 @@ njs_regexp_prototype_symbol_split(njs_vm_t *vm, njs_value_t *args,
     const u_char       *start, *end;
     njs_string_prop_t  s, sv;
     njs_value_t        arguments[2];
-
-    static const njs_value_t  string_lindex = njs_string("lastIndex");
-    static const njs_value_t  string_flags = njs_string("flags");
 
     rx = njs_argument(args, 0);
 

--- a/src/njs_scope.c
+++ b/src/njs_scope.c
@@ -167,13 +167,13 @@ njs_scope_value_index(njs_vm_t *vm, const njs_value_t *src, njs_uint_t runtime,
     uint32_t            value_size, size, length;
     njs_int_t           ret;
     njs_str_t           str;
-    njs_bool_t          long_string;
+    njs_bool_t          is_string;
     njs_value_t         *value;
     njs_string_t        *string;
     njs_lvlhsh_t        *values_hash;
     njs_lvlhsh_query_t  lhq;
 
-    long_string = 0;
+    is_string = 0;
     value_size = sizeof(njs_value_t);
 
     if (njs_is_string(src)) {
@@ -182,9 +182,7 @@ njs_scope_value_index(njs_vm_t *vm, const njs_value_t *src, njs_uint_t runtime,
         size = (uint32_t) str.length;
         start = str.start;
 
-        if (src->short_string.size == NJS_STRING_LONG) {
-            long_string = 1;
-        }
+        is_string = 1;
 
     } else {
         size = value_size;
@@ -207,8 +205,8 @@ njs_scope_value_index(njs_vm_t *vm, const njs_value_t *src, njs_uint_t runtime,
         *index = (njs_index_t *) ((u_char *) value + sizeof(njs_value_t));
 
     } else {
-        if (long_string) {
-            length = src->long_string.data->length;
+        if (is_string) {
+            length = src->string.data->length;
 
             if (size != length && length > NJS_STRING_MAP_STRIDE) {
                 size = njs_string_map_offset(size)
@@ -227,14 +225,15 @@ njs_scope_value_index(njs_vm_t *vm, const njs_value_t *src, njs_uint_t runtime,
 
         *value = *src;
 
-        if (long_string) {
+        if (is_string) {
             string = (njs_string_t *) ((u_char *) value + sizeof(njs_value_t)
                                        + sizeof(njs_index_t));
 
-            value->long_string.data = string;
+            value->string.data = string;
 
             string->start = (u_char *) string + sizeof(njs_string_t);
-            string->length = src->long_string.data->length;
+            string->length = src->string.data->length;
+            string->size = src->string.data->size;
 
             memcpy(string->start, start, size);
         }

--- a/src/njs_string.h
+++ b/src/njs_string.h
@@ -73,6 +73,7 @@
 struct njs_string_s {
     u_char    *start;
     uint32_t  length;   /* Length in UTF-8 characters. */
+    uint32_t  size;
 };
 
 

--- a/src/njs_symbol.c
+++ b/src/njs_symbol.c
@@ -9,17 +9,17 @@
 
 
 static const njs_value_t  njs_symbol_async_iterator_name =
-                            njs_long_string("Symbol.asyncIterator");
+                            njs_string("Symbol.asyncIterator");
 static const njs_value_t  njs_symbol_has_instance_name =
-                            njs_long_string("Symbol.hasInstance");
+                            njs_string("Symbol.hasInstance");
 static const njs_value_t  njs_symbol_is_concat_spreadable_name =
-                            njs_long_string("Symbol.isConcatSpreadable");
+                            njs_string("Symbol.isConcatSpreadable");
 static const njs_value_t  njs_symbol_iterator_name =
-                            njs_long_string("Symbol.iterator");
+                            njs_string("Symbol.iterator");
 static const njs_value_t  njs_symbol_match_name =
                             njs_string("Symbol.match");
 static const njs_value_t  njs_symbol_match_all_name =
-                            njs_long_string("Symbol.matchAll");
+                            njs_string("Symbol.matchAll");
 static const njs_value_t  njs_symbol_replace_name =
                             njs_string("Symbol.replace");
 static const njs_value_t  njs_symbol_search_name =
@@ -29,11 +29,11 @@ static const njs_value_t  njs_symbol_species_name =
 static const njs_value_t  njs_symbol_split_name =
                             njs_string("Symbol.split");
 static const njs_value_t  njs_symbol_to_primitive_name =
-                            njs_long_string("Symbol.toPrimitive");
+                            njs_string("Symbol.toPrimitive");
 static const njs_value_t  njs_symbol_to_string_tag_name =
-                            njs_long_string("Symbol.toStringTag");
+                            njs_string("Symbol.toStringTag");
 static const njs_value_t  njs_symbol_unscopables_name =
-                            njs_long_string("Symbol.unscopables");
+                            njs_string("Symbol.unscopables");
 
 
 static const njs_value_t  *njs_symbol_names[NJS_SYMBOL_KNOWN_MAX] = {
@@ -247,7 +247,7 @@ static const njs_object_prop_t  njs_symbol_constructor_properties[] =
     NJS_DECLARE_PROP_VALUE("hasInstance",
                            njs_wellknown_symbol(NJS_SYMBOL_HAS_INSTANCE), 0),
 
-    NJS_DECLARE_PROP_LVALUE("isConcatSpreadable",
+    NJS_DECLARE_PROP_VALUE("isConcatSpreadable",
                      njs_wellknown_symbol(NJS_SYMBOL_IS_CONCAT_SPREADABLE), 0),
 
     NJS_DECLARE_PROP_VALUE("iterator",

--- a/src/njs_typed_array.c
+++ b/src/njs_typed_array.c
@@ -435,7 +435,7 @@ njs_typed_array_writable(njs_vm_t *vm, njs_typed_array_t *array)
 
 static const njs_value_t  njs_typed_array_uint8_tag = njs_string("Uint8Array");
 static const njs_value_t  njs_typed_array_uint8_clamped_tag =
-                                        njs_long_string("Uint8ClampedArray");
+                                               njs_string("Uint8ClampedArray");
 static const njs_value_t  njs_typed_array_int8_tag = njs_string("Int8Array");
 static const njs_value_t  njs_typed_array_uint16_tag =
                                                     njs_string("Uint16Array");
@@ -2751,8 +2751,7 @@ static const njs_object_prop_t  njs_typed_array_u8_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1), 0),
 };
 
 
@@ -2768,8 +2767,7 @@ static const njs_object_prop_t  njs_typed_array_u8_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1), 0),
 };
 
 
@@ -2793,7 +2791,7 @@ static const njs_object_prop_t  njs_typed_array_u8c_constructor_props[] =
     {
         .type = NJS_PROPERTY,
         .name = njs_string("name"),
-        .u.value = njs_long_string("Uint8ClampedArray"),
+        .u.value = njs_string("Uint8ClampedArray"),
         .configurable = 1,
     },
 
@@ -2801,8 +2799,7 @@ static const njs_object_prop_t  njs_typed_array_u8c_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1), 0),
 };
 
 
@@ -2818,8 +2815,7 @@ static const njs_object_prop_t  njs_typed_array_u8c_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1), 0),
 };
 
 
@@ -2846,8 +2842,7 @@ static const njs_object_prop_t  njs_typed_array_i8_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1), 0),
 };
 
 
@@ -2863,8 +2858,7 @@ static const njs_object_prop_t  njs_typed_array_i8_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 1), 0),
 };
 
 
@@ -2891,8 +2885,7 @@ static const njs_object_prop_t  njs_typed_array_u16_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2), 0),
 };
 
 
@@ -2908,8 +2901,7 @@ static const njs_object_prop_t  njs_typed_array_u16_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2), 0),
 };
 
 
@@ -2936,8 +2928,7 @@ static const njs_object_prop_t  njs_typed_array_i16_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2), 0),
 };
 
 
@@ -2953,8 +2944,7 @@ static const njs_object_prop_t  njs_typed_array_i16_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 2), 0),
 };
 
 
@@ -2981,8 +2971,7 @@ static const njs_object_prop_t  njs_typed_array_u32_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4), 0),
 };
 
 
@@ -2998,8 +2987,7 @@ static const njs_object_prop_t  njs_typed_array_u32_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4), 0),
 };
 
 
@@ -3026,8 +3014,7 @@ static const njs_object_prop_t  njs_typed_array_i32_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4), 0),
 };
 
 
@@ -3043,8 +3030,7 @@ static const njs_object_prop_t  njs_typed_array_i32_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4), 0),
 };
 
 
@@ -3071,8 +3057,7 @@ static const njs_object_prop_t  njs_typed_array_f32_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4), 0),
 };
 
 
@@ -3088,8 +3073,7 @@ static const njs_object_prop_t  njs_typed_array_f32_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 4), 0),
 };
 
 
@@ -3116,8 +3100,7 @@ static const njs_object_prop_t  njs_typed_array_f64_constructor_props[] =
 
     NJS_DECLARE_PROP_HANDLER("prototype", njs_object_prototype_create, 0, 0, 0),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 8),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 8), 0),
 };
 
 
@@ -3133,8 +3116,7 @@ static const njs_object_prop_t  njs_typed_array_f64_prototype_properties[] =
                              njs_object_prototype_create_constructor,
                              0, 0, NJS_OBJECT_PROP_VALUE_CW),
 
-    NJS_DECLARE_PROP_LVALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 8),
-                            0),
+    NJS_DECLARE_PROP_VALUE("BYTES_PER_ELEMENT", njs_value(NJS_NUMBER, 1, 8), 0),
 };
 
 

--- a/src/njs_vmcode.c
+++ b/src/njs_vmcode.c
@@ -2190,8 +2190,6 @@ njs_vmcode_instance_of(njs_vm_t *vm, njs_value_t *object,
     njs_function_t  *function;
     njs_jump_off_t  ret;
 
-    static const njs_value_t prototype_string = njs_string("prototype");
-
     if (!njs_is_function(constructor)) {
         njs_type_error(vm, "right argument is not callable");
         return NJS_ERROR;
@@ -2207,7 +2205,7 @@ njs_vmcode_instance_of(njs_vm_t *vm, njs_value_t *object,
 
     if (njs_is_object(object)) {
         ret = njs_value_property(vm, constructor,
-                                 njs_value_arg(&prototype_string), &value);
+                                 njs_value_arg(&njs_string_prototype), &value);
 
         if (njs_slow_path(ret == NJS_ERROR)) {
             return ret;
@@ -2521,8 +2519,6 @@ njs_function_new_object(njs_vm_t *vm, njs_value_t *constructor)
     njs_function_t  *function;
     njs_jump_off_t  ret;
 
-    const njs_value_t prototype_string = njs_string("prototype");
-
     object = njs_object_alloc(vm);
     if (njs_slow_path(object == NULL)) {
         return NULL;
@@ -2538,8 +2534,8 @@ njs_function_new_object(njs_vm_t *vm, njs_value_t *constructor)
         constructor = &bound;
     }
 
-    ret = njs_value_property(vm, constructor, njs_value_arg(&prototype_string),
-                             &proto);
+    ret = njs_value_property(vm, constructor,
+                             njs_value_arg(&njs_string_prototype), &proto);
 
     if (njs_slow_path(ret == NJS_ERROR)) {
         return NULL;

--- a/src/test/njs_benchmark.c
+++ b/src/test/njs_benchmark.c
@@ -94,6 +94,10 @@ njs_time(void)
 }
 
 
+static const njs_value_t  name_key = njs_string("name");
+static const njs_value_t  usec_key = njs_string("usec");
+static const njs_value_t  times_key = njs_string("times");
+
 static njs_int_t
 njs_benchmark_test(njs_vm_t *parent, njs_opts_t *opts, njs_value_t *report,
     njs_benchmark_test_t *test)
@@ -107,10 +111,6 @@ njs_benchmark_test(njs_vm_t *parent, njs_opts_t *opts, njs_value_t *report,
     njs_bool_t    success;
     njs_value_t   *result, retval, name, usec, times;
     njs_vm_opt_t  options;
-
-    static const njs_value_t  name_key = njs_string("name");
-    static const njs_value_t  usec_key = njs_string("usec");
-    static const njs_value_t  times_key = njs_string("times");
 
     njs_vm_opt_init(&options);
 
@@ -493,6 +493,9 @@ static njs_str_t  code = njs_str(
     "}");
 
 
+static const njs_str_t  compare = njs_str("compare");
+
+
 int njs_cdecl
 main(int argc, char **argv)
 {
@@ -517,8 +520,6 @@ main(int argc, char **argv)
         "  -d                dump report as a JSON file.\n"
         "  -c <report file>  compare with previous report.\n"
         "  -h                this help.\n";
-
-    static const njs_str_t  compare = njs_str("compare");
 
     njs_memzero(&opts, sizeof(njs_opts_t));
     opts.prefix = "";
@@ -682,13 +683,14 @@ njs_benchmark_preinit(njs_vm_t *vm)
 }
 
 
+static const njs_str_t  benchmark = njs_str("benchmark");
+
+
 static njs_int_t
 njs_benchmark_init(njs_vm_t *vm)
 {
     njs_int_t           ret;
     njs_opaque_value_t  value;
-
-    static const njs_str_t  benchmark = njs_str("benchmark");
 
     ret = njs_vm_external_create(vm, njs_value_arg(&value),
                                  njs_benchmark_proto_id, NULL, 1);


### PR DESCRIPTION
### Proposed changes

(This PR is clone of unintentionally closed PR 777)

This is series of commits which introduce internal atomic representation for
strings, symbols and small numbers as keys for access object properties.

These commits are intended to speed up access to object properties.

Step 1:
Remove long strings from njs core to simplify code and make it more regular.
Reserve atom_id field in njs_value_t.

Notes:
a) Each commit is fully and successfully tested for regressions with all local tests;
b) This PR is draft for internal review, I'll extend it by additional commits as
they will be merged here from my hg sandbox.
c) As soon as last commit will be added/reviewed, draft status from this PR can be removed,
and PR applied then.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [X] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
