### PR TITLE
Add missed syntax error for await in template literal.

### DIFF
--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -27,6 +27,7 @@ struct njs_parser_scope_s {
     uint8_t                         dest_disable;
     uint8_t                         async;
     uint32_t                        in_args;
+    uint32_t                        in_tagged_template;
 };
 
 

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -19821,6 +19821,12 @@ static njs_unit_test_t  njs_test[] =
     { njs_str("async function f1() {try {f(await f1)} catch(e) {}}"),
       njs_str("SyntaxError: await in arguments not supported in 1") },
 
+    { njs_str("(async () => (function (){}) `${(async () => 1)(await 1)}`)()"),
+      njs_str("SyntaxError: await in arguments not supported in 1") },
+
+    { njs_str("(async () => (function (){}) `${await 1}`)()"),
+      njs_str("SyntaxError: await in tagged template not supported in 1") },
+
     { njs_str("async function af() {await encrypt({},}"),
       njs_str("SyntaxError: Unexpected token \"}\" in 1") },
 


### PR DESCRIPTION
This fixes issue #836 on github.
