### PR TITLE
QuickJS: fixed ngx_qjs_string().

### DIFF
--- a/nginx/ngx_js.c
+++ b/nginx/ngx_js.c
@@ -1482,12 +1482,10 @@ ngx_qjs_string(JSContext *cx, JSValueConst val, ngx_str_t *dst)
 
 string:
 
-    str = JS_ToCString(cx, val);
+    str = JS_ToCStringLen(cx, &len, val);
     if (str == NULL) {
         return NGX_ERROR;
     }
-
-    len = strlen(str);
 
     start = njs_mp_alloc(e->pool, len);
     if (start == NULL) {


### PR DESCRIPTION
Fix the function to properly handler strings like "\0" which happens in tests. In js_fetch_objects.t:
```
for (var i = 0; i < 128; i++) {
  var c = String.fromCodePoint(i);
```

Refactored out from qjs fetch patches.