### PR TITLE
QuickJS: calling njs_chb_destroy() in qjs_string_create_chb() internally.

### DIFF
--- a/external/qjs_query_string_module.c
+++ b/external/qjs_query_string_module.c
@@ -171,7 +171,6 @@ static JSValue
 qjs_query_string_decode(JSContext *cx, const u_char *start, size_t size)
 {
     u_char                *dst;
-    JSValue               ret;
     uint32_t              cp;
     njs_chb_t             chain;
     const u_char          *p, *end;
@@ -250,11 +249,7 @@ qjs_query_string_decode(JSContext *cx, const u_char *start, size_t size)
     }
 
 
-    ret = qjs_string_create_chb(cx, &chain);
-
-    njs_chb_destroy(&chain);
-
-    return ret;
+    return qjs_string_create_chb(cx, &chain);
 }
 
 
@@ -280,8 +275,6 @@ qjs_query_string_escape(JSContext *cx, JSValueConst this_val, int argc,
     }
 
     ret = qjs_string_create_chb(cx, &chain);
-
-    njs_chb_destroy(&chain);
 
     JS_FreeCString(cx, (char *) str.start);
 
@@ -733,7 +726,7 @@ qjs_query_string_stringify_internal(JSContext *cx, JSValue obj, njs_str_t *sep,
 {
     int             rc;
     uint32_t        n, length;
-    JSValue         key, val, ret;
+    JSValue         key, val;
     njs_str_t       sep_val, eq_val;
     njs_chb_t       chain;
     JSPropertyEnum  *ptab;
@@ -809,11 +802,7 @@ qjs_query_string_stringify_internal(JSContext *cx, JSValue obj, njs_str_t *sep,
         qjs_free_prop_enum(cx, ptab, length);
     }
 
-    ret = qjs_string_create_chb(cx, &chain);
-
-    njs_chb_destroy(&chain);
-
-    return ret;
+    return qjs_string_create_chb(cx, &chain);
 
 fail:
 

--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -6400,10 +6400,9 @@ ngx_http_qjs_header_generic(JSContext *cx, ngx_http_request_t *r,
     ngx_list_t *headers, ngx_table_elt_t **ph, ngx_str_t *name,
     JSPropertyDescriptor *pdesc, unsigned flags)
 {
-    int               ret;
     u_char            sep;
-    njs_chb_t         chain;
     JSValue           val;
+    njs_chb_t         chain;
     ngx_uint_t        i;
     ngx_list_part_t  *part;
     ngx_table_elt_t  *header, *h;
@@ -6493,6 +6492,10 @@ ngx_http_qjs_header_generic(JSContext *cx, ngx_http_request_t *r,
         return 1;
     }
 
+    if (pdesc == NULL) {
+        return 1;
+    }
+
     NJS_CHB_CTX_INIT(&chain, cx);
 
     sep = flags & NJS_HEADER_SEMICOLON ? ';' : ',';
@@ -6503,24 +6506,15 @@ ngx_http_qjs_header_generic(JSContext *cx, ngx_http_request_t *r,
         njs_chb_append_literal(&chain, " ");
     }
 
-    ret = 1;
-
-    if (pdesc != NULL) {
-        pdesc->flags = JS_PROP_ENUMERABLE;
-        pdesc->getter = JS_UNDEFINED;
-        pdesc->setter = JS_UNDEFINED;
-        pdesc->value = qjs_string_create_chb(cx, &chain);
-        if (JS_IsException(pdesc->value)) {
-            ret = -1;
-            goto done;
-        }
+    pdesc->flags = JS_PROP_ENUMERABLE;
+    pdesc->getter = JS_UNDEFINED;
+    pdesc->setter = JS_UNDEFINED;
+    pdesc->value = qjs_string_create_chb(cx, &chain);
+    if (JS_IsException(pdesc->value)) {
+        return -1;
     }
 
-done:
-
-    njs_chb_destroy(&chain);
-
-    return ret;
+    return 1;
 }
 
 

--- a/src/qjs.c
+++ b/src/qjs.c
@@ -1015,6 +1015,8 @@ qjs_string_create_chb(JSContext *cx, njs_chb_t *chain)
     njs_str_t  str;
 
     ret = njs_chb_join(chain, &str);
+    njs_chb_destroy(chain);
+
     if (ret != NJS_OK) {
         return JS_ThrowInternalError(cx, "failed to create string");
     }


### PR DESCRIPTION
No functional changes.

Refactored out from qjs fetch patches.
