### PR TITLE
QuickJS: using JS_AddIntrinsicBigInt() if detected.

### DIFF
--- a/auto/quickjs
+++ b/auto/quickjs
@@ -137,6 +137,29 @@ if [ $NJS_TRY_QUICKJS = YES ]; then
 
         . auto/feature
 
+        njs_feature="QuickJS JS_AddIntrinsicBigInt()"
+        njs_feature_name=NJS_HAVE_QUICKJS_ADD_INTRINSIC_BIG_INT
+        njs_feature_test="#if defined(__GNUC__) && (__GNUC__ >= 8)
+                          #pragma GCC diagnostic push
+                          #pragma GCC diagnostic ignored \"-Wcast-function-type\"
+                          #endif
+
+                          #include <quickjs.h>
+
+                          int main() {
+                              JSRuntime *rt;
+                              JSContext *ctx;
+
+                              rt = JS_NewRuntime();
+                              ctx = JS_NewContextRaw(rt);
+                              JS_AddIntrinsicBigInt(ctx);
+                              JS_FreeContext(ctx);
+                              JS_FreeRuntime(rt);
+                              return 0;
+                         }"
+
+        . auto/feature
+
         njs_feature="QuickJS version"
         njs_feature_name=NJS_QUICKJS_VERSION
         njs_feature_run=value

--- a/src/qjs.c
+++ b/src/qjs.c
@@ -165,7 +165,9 @@ qjs_new_context(JSRuntime *rt, qjs_module_t **addons)
     JS_AddIntrinsicMapSet(ctx);
     JS_AddIntrinsicTypedArrays(ctx);
     JS_AddIntrinsicPromise(ctx);
+#ifdef NJS_HAVE_QUICKJS_ADD_INTRINSIC_BIG_INT
     JS_AddIntrinsicBigInt(ctx);
+#endif
     JS_AddIntrinsicEval(ctx);
 
     for (module = qjs_modules; *module != NULL; module++) {


### PR DESCRIPTION
In quickjs JS_AddIntrinsicBigInt() is moved from public API to JS_AddIntrinsicBaseObjects():

commit 6d6893bfa3d383d4952b67954003800aba1f4be8
Author: Fabrice Bellard <fabrice@bellard.org>
Date:   Wed Mar 19 12:33:54 2025 +0100

    fixed BigInt hashing - removed -fno-bigint in qjsc and JS_AddIntrinsicBigInt() (BigInt is now considered as a base object)
