### PR TITLE
Tag some char arrays with __attribute__((__nonstring__))

### DIFF
--- a/auto/clang
+++ b/auto/clang
@@ -172,6 +172,20 @@ njs_feature_test="__attribute__((no_sanitize(\"undefined\"))) int main(void) {
 . auto/feature
 
 
+njs_feature="GCC __attribute__ nonstring"
+njs_feature_name=NJS_HAVE_GCC_ATTRIBUTE_NONSTRING
+njs_feature_run=no
+njs_feature_incs=
+njs_feature_libs=
+njs_feature_test="int main(void) {
+                      static const char str[3] __attribute__((nonstring)) =
+                          \"ABC\";
+
+                      return !!str[0];
+                  }"
+. auto/feature
+
+
 njs_feature="Address sanitizer"
 njs_feature_name=NJS_HAVE_ADDRESS_SANITIZER
 njs_feature_run=no

--- a/external/qjs_query_string_module.c
+++ b/external/qjs_query_string_module.c
@@ -537,7 +537,7 @@ qjs_string_encode(const uint32_t *escape, size_t size, const u_char *src,
     u_char *dst)
 {
     uint8_t              byte;
-    static const u_char  hex[16] = "0123456789ABCDEF";
+    static const u_char  hex[16] NJS_NONSTRING = "0123456789ABCDEF";
 
     do {
         byte = *src++;

--- a/src/njs_clang.h
+++ b/src/njs_clang.h
@@ -162,6 +162,14 @@ njs_leading_zeros64(uint64_t x)
 #endif
 
 
+#if (NJS_HAVE_GCC_ATTRIBUTE_NONSTRING)
+#define NJS_NONSTRING      __attribute__((nonstring))
+
+#else
+#define NJS_NONSTRING
+#endif
+
+
 #if (NJS_CLANG)
 /* Any __asm__ directive disables loop vectorization in GCC and Clang. */
 #define njs_pragma_loop_disable_vectorization  __asm__("")

--- a/src/njs_sprintf.c
+++ b/src/njs_sprintf.c
@@ -95,8 +95,8 @@ njs_vsprintf(u_char *buf, u_char *end, const char *fmt, va_list args)
     njs_bool_t     sign;
     njs_sprintf_t  spf;
 
-    static const u_char  hexadecimal[16] = "0123456789abcdef";
-    static const u_char  HEXADECIMAL[16] = "0123456789ABCDEF";
+    static const u_char  hexadecimal[16] NJS_NONSTRING = "0123456789abcdef";
+    static const u_char  HEXADECIMAL[16] NJS_NONSTRING = "0123456789ABCDEF";
     static const u_char  nan[] = "[nan]";
     static const u_char  infinity[] = "[infinity]";
 

--- a/src/njs_string.c
+++ b/src/njs_string.c
@@ -309,7 +309,7 @@ njs_encode_hex(njs_str_t *dst, const njs_str_t *src)
     size_t        i, len;
     const u_char  *start;
 
-    static const u_char  hex[16] = "0123456789abcdef";
+    static const u_char  hex[16] NJS_NONSTRING = "0123456789abcdef";
 
     len = src->length;
     start = src->start;

--- a/src/njs_string.h
+++ b/src/njs_string.h
@@ -209,7 +209,7 @@ njs_string_encode(const uint32_t *escape, size_t size, const u_char *src,
     u_char *dst)
 {
     uint8_t              byte;
-    static const u_char  hex[16] = "0123456789ABCDEF";
+    static const u_char  hex[16] NJS_NONSTRING = "0123456789ABCDEF";
 
     do {
         byte = *src++;

--- a/src/qjs_buffer.c
+++ b/src/qjs_buffer.c
@@ -2354,7 +2354,7 @@ qjs_hex_encode(JSContext *ctx, const njs_str_t *src, njs_str_t *dst)
     size_t        i, len;
     const u_char  *start;
 
-    static const u_char  hex[16] = "0123456789abcdef";
+    static const u_char  hex[16] NJS_NONSTRING = "0123456789abcdef";
 
     len = src->length;
     start = src->start;


### PR DESCRIPTION
GCC 15 implements a new warning `-Wunterminated-string-initialization` that is also enabled by `-Wextra` that we enable.

This causes compilation failures (due to -Werror) due to the likes of

```c
static const u_char  hex[16] = "0123456789ABCDEF";
```

E.g.

```
src/njs_string.h: In function ‘njs_string_encode’:
src/njs_string.h:212:36: error: initializer-string for array of ‘unsigned char’ truncates NUL terminator but destination lacks ‘nonstring’ attribute (17 chars into 16 available) [-Werror=unterminated-string-initialization]
  212 |     static const u_char  hex[16] = "0123456789ABCDEF";
      |                                    ^~~~~~~~~~~~~~~~~~
```

These are very much meant not to be NUL terminated.

Now we could just disable this new warning. But I think it is worth leaving it enabled (the GCC developers also obviously feel it's useful enough to enable under -Wexta), anything that helps the compiler help us avoid silly mistakes is a good thing(tm), particularly in the current climate.

So rather than disable this warning, we can make use of the GCC "nonstring" variable attribute `__attribute__((__nonstring__))`. 

This attribute is used to mark character arrays that are intentionally not NUL terminated.

So the above example would become (we of course wrap it in a more friendly name `NJS_NONSTRING`)

```c
static const u_char  hex[16] NJS_NONSTRING = "0123456789ABCDEF";
```

* The first commit adds a wrapper around `__attribute__((__nonstring__))`

* The second commit tags various character arrays with this attribute.

Note: This was done with an eye towards the atomic strings work which removes the need for one of the attribute tags.
 
```
The following changes since commit d34fcb03cf2378a644a3c7366d58cbddc2771cbd:

  HTTP: fixed r.subrequest() error handling. (2024-06-12 15:09:21 -0700)

are available in the Git repository at:

  git@github.com:ac000/njs.git wusi

for you to fetch changes up to a00cc6d3897393f723d9f11f78651f4cbcb8cc76:

  Tag various character arrays with NJS_NONSTRING (2025-03-20 17:32:58 +0000)

----------------------------------------------------------------
Andrew Clayton (2):
      auto/clang: Add a NJS_NONSTRING macro
      Tag various character arrays with NJS_NONSTRING

 auto/clang        | 14 ++++++++++++++
 src/njs_clang.h   |  8 ++++++++
 src/njs_sprintf.c |  4 ++--
 src/njs_string.c  |  2 +-
 src/njs_string.h  |  2 +-
 5 files changed, 26 insertions(+), 4 deletions(-)
```