### PR TITLE
QuickJS: fixed compatibility issues with QuickJS-NG 0.9.0.

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           git clone https://github.com/quickjs-ng/quickjs quickjs-ng
           cd quickjs-ng
-          git checkout v0.8.0
+          git checkout v0.9.0
           CFLAGS="$CC_OPT -fPIC" LDFLAGS=$LD_OPT cmake -B build
           cmake --build build --target qjs -j $(nproc)
 

--- a/auto/quickjs
+++ b/auto/quickjs
@@ -137,6 +137,29 @@ if [ $NJS_TRY_QUICKJS = YES ]; then
 
         . auto/feature
 
+        njs_feature="QuickJS JS_IsArray()"
+        njs_feature_name=NJS_HAVE_QUICKJS_IS_ARRAY_SINGLE_ARG
+        njs_feature_test="#if defined(__GNUC__) && (__GNUC__ >= 8)
+                          #pragma GCC diagnostic push
+                          #pragma GCC diagnostic ignored \"-Wcast-function-type\"
+                          #endif
+
+                          #include <quickjs.h>
+
+                          int main() {
+                              JSRuntime *rt;
+                              JSContext *ctx;
+
+                              rt = JS_NewRuntime();
+                              ctx = JS_NewContext(rt);
+                              (void) JS_IsArray(JS_UNDEFINED);
+                              JS_FreeContext(ctx);
+                              JS_FreeRuntime(rt);
+                              return 0;
+                         }"
+
+        . auto/feature
+
         njs_feature="QuickJS JS_AddIntrinsicBigInt()"
         njs_feature_name=NJS_HAVE_QUICKJS_ADD_INTRINSIC_BIG_INT
         njs_feature_test="#if defined(__GNUC__) && (__GNUC__ >= 8)

--- a/external/qjs_query_string_module.c
+++ b/external/qjs_query_string_module.c
@@ -403,7 +403,7 @@ qjs_query_string_append(JSContext *cx, JSValue object, const u_char *key,
             goto exception;
         }
 
-    } else if (JS_IsArray(cx, prev)) {
+    } else if (qjs_is_array(cx, prev)) {
         length = JS_GetPropertyStr(cx, prev, "length");
 
         if (JS_ToUint32(cx, &len, length) < 0) {
@@ -762,7 +762,7 @@ qjs_query_string_stringify_internal(JSContext *cx, JSValue obj, njs_str_t *sep,
             goto fail;
         }
 
-        if (JS_IsArray(cx, val)) {
+        if (qjs_is_array(cx, val)) {
             key = JS_AtomToString(cx, ptab[n].atom);
             if (JS_IsException(key)) {
                 JS_FreeValue(cx, val);

--- a/external/qjs_webcrypto_module.c
+++ b/external/qjs_webcrypto_module.c
@@ -4556,7 +4556,7 @@ qjs_key_usage(JSContext *cx, JSValue value, unsigned *mask)
     njs_str_t              s;
     qjs_webcrypto_entry_t  *e;
 
-    if (!JS_IsArray(cx, value)) {
+    if (!qjs_is_array(cx, value)) {
         JS_ThrowTypeError(cx, "\"keyUsages\" argument must be an Array");
         return JS_EXCEPTION;
     }

--- a/external/qjs_xml_module.c
+++ b/external/qjs_xml_module.c
@@ -795,7 +795,7 @@ qjs_xml_node_tags_modify(JSContext *cx, JSValue obj, njs_str_t *name,
         return -1;
     }
 
-    if (!JS_IsArray(cx, setval)) {
+    if (!qjs_is_array(cx, setval)) {
         JS_ThrowTypeError(cx, "setval is not an array");
         return -1;
     }

--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -4910,7 +4910,7 @@ ngx_http_qjs_ext_args(JSContext *cx, JSValueConst this_val)
                 goto exception;
             }
 
-        } else if (JS_IsArray(cx, prev)) {
+        } else if (qjs_is_array(cx, prev)) {
             length = JS_GetPropertyStr(cx, prev, "length");
 
             if (JS_ToUint32(cx, &len, length)) {
@@ -6729,7 +6729,7 @@ ngx_http_qjs_headers_out_handler(JSContext *cx, ngx_http_request_t *r,
         return 1;
     }
 
-    if (JS_IsArray(cx, *value)) {
+    if (qjs_is_array(cx, *value)) {
         v = JS_GetPropertyStr(cx, *value, "length");
         if (JS_IsException(v)) {
             return -1;
@@ -6750,7 +6750,7 @@ ngx_http_qjs_headers_out_handler(JSContext *cx, ngx_http_request_t *r,
     ph = &header;
 
     for (i = 0; i < (uint32_t) length; i++) {
-        if (JS_IsArray(cx, *value)) {
+        if (qjs_is_array(cx, *value)) {
             v = JS_GetPropertyUint32(cx, *value, i);
             if (JS_IsException(v)) {
                 return -1;
@@ -6759,7 +6759,7 @@ ngx_http_qjs_headers_out_handler(JSContext *cx, ngx_http_request_t *r,
 
         rc = ngx_qjs_string(cx, v, &s);
 
-        if (JS_IsArray(cx, *value)) {
+        if (qjs_is_array(cx, *value)) {
             JS_FreeValue(cx, v);
         }
 
@@ -6832,7 +6832,7 @@ ngx_http_qjs_headers_out_special_handler(JSContext *cx, ngx_http_request_t *r,
     }
 
     if (value != NULL) {
-        if (JS_IsArray(cx, *value)) {
+        if (qjs_is_array(cx, *value)) {
             len = JS_GetPropertyStr(cx, *value, "length");
             if (JS_IsException(len)) {
                 return -1;
@@ -6860,7 +6860,7 @@ ngx_http_qjs_headers_out_special_handler(JSContext *cx, ngx_http_request_t *r,
 
     rc = ngx_qjs_string(cx, setval, &s);
 
-    if (value != NULL && JS_IsArray(cx, *value)) {
+    if (value != NULL && qjs_is_array(cx, *value)) {
         JS_FreeValue(cx, setval);
     }
 
@@ -7071,7 +7071,7 @@ ngx_http_qjs_headers_out_content_type(JSContext *cx, ngx_http_request_t *r,
         return 1;
     }
 
-    if (JS_IsArray(cx, *value)) {
+    if (qjs_is_array(cx, *value)) {
         len = JS_GetPropertyStr(cx, *value, "length");
         if (JS_IsException(len)) {
             return -1;
@@ -7095,7 +7095,7 @@ ngx_http_qjs_headers_out_content_type(JSContext *cx, ngx_http_request_t *r,
 
     rc = ngx_qjs_string(cx, setval, &s);
 
-    if (JS_IsArray(cx, *value)) {
+    if (qjs_is_array(cx, *value)) {
         JS_FreeValue(cx, setval);
     }
 

--- a/src/qjs.h
+++ b/src/qjs.h
@@ -27,6 +27,10 @@
 
 #include <quickjs.h>
 
+#ifndef JS_BOOL
+#define JS_BOOL bool
+#endif
+
 #if defined(__GNUC__) && (__GNUC__ >= 8)
 #pragma GCC diagnostic pop
 #endif
@@ -144,13 +148,17 @@ static inline JS_BOOL JS_IsNullOrUndefined(JSValueConst v)
            || JS_VALUE_GET_TAG(v) == JS_TAG_UNDEFINED;
 }
 
-
 #ifdef NJS_HAVE_QUICKJS_IS_SAME_VALUE
 #define qjs_is_same_value(cx, a, b) JS_IsSameValue(cx, a, b)
 #else
 #define qjs_is_same_value(cx, a, b) JS_SameValue(cx, a, b)
 #endif
 
+#ifdef NJS_HAVE_QUICKJS_IS_ARRAY_SINGLE_ARG
+#define qjs_is_array(cx, a) JS_IsArray(a)
+#else
+#define qjs_is_array(cx, a) JS_IsArray(cx, a)
+#endif
 
 extern qjs_module_t              *qjs_modules[];
 

--- a/src/qjs_buffer.c
+++ b/src/qjs_buffer.c
@@ -440,7 +440,7 @@ qjs_buffer_concat(JSContext *ctx, JSValueConst this_val, int argc,
 
     list = argv[0];
 
-    if (!JS_IsArray(ctx, list)) {
+    if (!qjs_is_array(ctx, list)) {
         return JS_ThrowTypeError(ctx,
                             "\"list\" argument must be an instance of Array");
     }


### PR DESCRIPTION
This fixes #872 on Github.
