### PR TITLE
Fixed GCC 15 build with -Wunterminated-string-initialization.

### DIFF
--- a/external/qjs_query_string_module.c
+++ b/external/qjs_query_string_module.c
@@ -537,7 +537,7 @@ qjs_string_encode(const uint32_t *escape, size_t size, const u_char *src,
     u_char *dst)
 {
     uint8_t              byte;
-    static const u_char  hex[16] = "0123456789ABCDEF";
+    static const u_char  hex[] = "0123456789ABCDEF";
 
     do {
         byte = *src++;

--- a/src/njs_sprintf.c
+++ b/src/njs_sprintf.c
@@ -95,8 +95,8 @@ njs_vsprintf(u_char *buf, u_char *end, const char *fmt, va_list args)
     njs_bool_t     sign;
     njs_sprintf_t  spf;
 
-    static const u_char  hexadecimal[16] = "0123456789abcdef";
-    static const u_char  HEXADECIMAL[16] = "0123456789ABCDEF";
+    static const u_char  hexadecimal[] = "0123456789abcdef";
+    static const u_char  HEXADECIMAL[] = "0123456789ABCDEF";
     static const u_char  nan[] = "[nan]";
     static const u_char  infinity[] = "[infinity]";
 

--- a/src/njs_string.c
+++ b/src/njs_string.c
@@ -252,7 +252,7 @@ njs_encode_hex(njs_str_t *dst, const njs_str_t *src)
     size_t        i, len;
     const u_char  *start;
 
-    static const u_char  hex[16] = "0123456789abcdef";
+    static const u_char  hex[] = "0123456789abcdef";
 
     len = src->length;
     start = src->start;

--- a/src/njs_string.h
+++ b/src/njs_string.h
@@ -226,7 +226,7 @@ njs_string_encode(const uint32_t *escape, size_t size, const u_char *src,
     u_char *dst)
 {
     uint8_t              byte;
-    static const u_char  hex[16] = "0123456789ABCDEF";
+    static const u_char  hex[] = "0123456789ABCDEF";
 
     do {
         byte = *src++;

--- a/src/qjs_buffer.c
+++ b/src/qjs_buffer.c
@@ -2354,7 +2354,7 @@ qjs_hex_encode(JSContext *ctx, const njs_str_t *src, njs_str_t *dst)
     size_t        i, len;
     const u_char  *start;
 
-    static const u_char  hex[16] = "0123456789abcdef";
+    static const u_char  hex[] = "0123456789abcdef";
 
     len = src->length;
     start = src->start;


### PR DESCRIPTION
In file included from src/njs_main.h:48,
                 from src/njs_diyfp.c:12:
src/njs_string.h: In function ‘njs_string_encode’: src/njs_string.h:229:36: error: initializer-string for array of ‘unsigned char’
	truncates NUL terminator but destination lacks ‘nonstring’ attribute (
	17 chars into 16 available) [-Werror=unterminated-string-initialization]
  229 |     static const u_char  hex[16] = "0123456789ABCDEF";
