### PR TITLE
Tests: fixed js_body_filter.t.

### DIFF
--- a/nginx/t/js_body_filter.t
+++ b/nginx/t/js_body_filter.t
@@ -12,6 +12,8 @@ use strict;
 
 use Test::More;
 
+use Socket qw/ CRLF IPPROTO_TCP TCP_NODELAY /;
+
 BEGIN { use FindBin; chdir($FindBin::Bin); }
 
 use lib 'lib';
@@ -79,21 +81,6 @@ http {
             proxy_pass http://127.0.0.1:8081/source;
         }
     }
-
-    server {
-        listen       127.0.0.1:8081;
-        server_name  localhost;
-
-        location /source {
-            postpone_output 1;
-            js_content test.source;
-        }
-
-        location /nonutf8_source {
-            postpone_output 1;
-            js_content test.nonutf8_source;
-        }
-    }
 }
 
 EOF
@@ -124,39 +111,6 @@ $t->write_file('test.js', <<EOF);
         }
     }
 
-    function chain(chunks, i) {
-        if (i < chunks.length) {
-            chunks.r.send(chunks[i++]);
-            setTimeout(chunks.chain, chunks.delay, chunks, i);
-
-        } else {
-            chunks.r.finish();
-        }
-    }
-
-    function source(r) {
-        var chunks = ['AAA', 'BB', 'C', 'DDDD'];
-        chunks.delay = 5;
-        chunks.r = r;
-        chunks.chain = chain;
-
-        r.status = 200;
-        r.headersOut['Content-Length'] = chunks.reduce((a, b) => a + b.length, 0);
-        r.sendHeader();
-        chain(chunks, 0);
-    }
-
-    function nonutf8_source(r) {
-        var chunks = ['aaaa', 'bb', 'cc', 'dddd'].map(v=>Buffer.from(v, 'hex'));
-        chunks.delay = 5;
-        chunks.r = r;
-        chunks.chain = chain;
-
-        r.status = 200;
-        r.sendHeader();
-        chain(chunks, 0);
-    }
-
     function filter(r, data, flags) {
         if (flags.last || data.length >= Number(r.args.len)) {
             r.sendBuffer(`\${data}#`, flags);
@@ -178,11 +132,14 @@ $t->write_file('test.js', <<EOF);
     }
 
     export default {njs: test_njs, append, buffer_type, filter, forward,
-                    prepend, source, nonutf8_source, clear_content_length};
+                    prepend, clear_content_length};
 
 EOF
 
 $t->try_run('no njs body filter')->plan(8);
+
+$t->run_daemon(\&http_daemon, port(8081));
+$t->waitforsocket('127.0.0.1:' . port(8081));
 
 ###############################################################################
 
@@ -196,5 +153,82 @@ like(http_get('/filter?len=3'), qr/AAA#DDDD##$/, 'filter 3');
 like(http_get('/filter?len=2&dup=1'), qr/AAA#AAABB#BBDDDD#DDDD#$/,
 	'filter 2 dup');
 like(http_get('/prepend'), qr/XXXAAABBCDDDD$/, 'prepend');
+
+###############################################################################
+
+sub http_daemon {
+	my $port = shift;
+	my $delay = shift || 0.05;
+
+	my $server = IO::Socket::INET->new(
+		Proto => 'tcp',
+		LocalAddr => '127.0.0.1:' . $port,
+		Listen => 5,
+		Reuse => 1
+	) or die "Can't create listening socket: $!\n";
+
+	local $SIG{PIPE} = 'IGNORE';
+
+	while (my $client = $server->accept()) {
+		$client->autoflush(1);
+
+		setsockopt($client, IPPROTO_TCP, TCP_NODELAY, 1)
+			or die "Can't set TCP_NODELAY: $!\n";
+
+		my $headers = '';
+		my $uri = '';
+
+		while (<$client>) {
+			$headers .= $_;
+			last if (/^\x0d?\x0a?$/);
+		}
+
+		$uri = $1 if $headers =~ /^\S+\s+([^ ]+)\s+HTTP/i;
+		$uri =~ s/\?.*//;
+
+		log2c("(new connection $client $uri)");
+
+		if ($uri eq '/source') {
+			print $client
+				"HTTP/1.1 200 OK" . CRLF .
+				"Content-Length: 10" . CRLF .
+				"Connection: close" . CRLF .
+				CRLF;
+
+			print $client "AAA";
+			select undef, undef, undef, $delay;
+			print $client "BB";
+			select undef, undef, undef, $delay;
+			print $client "C";
+			select undef, undef, undef, $delay;
+			print $client "DDDD";
+
+		}  elsif ($uri eq '/nonutf8_source') {
+			print $client
+				"HTTP/1.1 200 OK" . CRLF .
+				"Content-Length: 6" . CRLF .
+				"Connection: close" . CRLF .
+				CRLF;
+
+			print $client "\xaa\xaa";
+			select undef, undef, undef, $delay;
+			print $client "\xbb";
+			select undef, undef, undef, $delay;
+			print $client "\xcc";
+			select undef, undef, undef, $delay;
+			print $client "\xdd\xdd";
+
+		} else {
+			print $client
+				"HTTP/1.1 404 Not Found" . CRLF .
+				"Connection: close" . CRLF .
+				CRLF;
+		}
+
+		$client->close();
+	}
+}
+
+sub log2c { Test::Nginx::log_core('||', @_); }
 
 ###############################################################################


### PR DESCRIPTION
The 1496ed3f commit made visible a problem with the fragile filter tests which depend on the exact sequence of data chunks. The fix is to use perl http server to ensure the order.

