### PR TITLE
HTTP: fixed GCC 15 build with -Wunterminated-string-initialization.

### DIFF
--- a/src/njs.h
+++ b/src/njs.h
@@ -187,7 +187,7 @@ struct njs_external_s {
 
     union {
         struct {
-            const char              value[15]; /* NJS_STRING_SHORT + 1. */
+            const char              *value;
             njs_prop_handler_t      handler;
             uint16_t                magic16;
             uint32_t                magic32;


### PR DESCRIPTION
ngx_http_js_module.c:936:22: error: initializer-string for array of ‘char’ truncates NUL terminator
 but destination lacks ‘nonstring’ attribute (16 chars into 15 available) [-Werror=unterminated-string-initialization]
  936 |             .value = "PeriodicSession",
      |                      ^~~~~~~~~~~~~~~~~
