### PR TITLE
Add missing null checks for njs_promise_create_function allocations

### DIFF
--- a/src/njs_promise.c
+++ b/src/njs_promise.c
@@ -457,6 +457,10 @@ njs_promise_trigger_reactions(njs_vm_t *vm, njs_value_t *value,
 
         function = njs_promise_create_function(vm,
                                                sizeof(njs_promise_context_t));
+        if (njs_slow_path(function == NULL)) {
+            return njs_value_arg(&njs_value_null);
+        }
+
         function->u.native = njs_promise_reaction_job;
 
         njs_set_data(&arguments[0], reaction, 0);
@@ -784,6 +788,11 @@ njs_promise_prototype_then(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     function = njs_promise_create_function(vm, sizeof(njs_promise_context_t));
+    if (njs_slow_path(function == NULL)) {
+        /* vm error is already set by njs_promise_create_function */
+        return NJS_ERROR;
+    }
+
     function->u.native = njs_promise_constructor;
 
     njs_set_function(&constructor, function);


### PR DESCRIPTION
### Proposed changes

Hi! 
I'm experimenting with memory pool limits for NJS and I've spotted 2 places where the result of
`njs_promise_create_function` call is dereferenced without proper checks. Causing segmentation fault on nullptr dereference.

I'm not able to share minimal example -- it's hard to hit precisely these two lines via memory allocation failure.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
