### PR TITLE
Add spaces in readme to clarify nginx compile command args with qjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ auto/configure --add-dynamic-module=<NJS_SRC_ROOT_DIR>/nginx
 To build with [QuickJS](https://nginx.org/en/docs/njs/engine.html) support, provide include and library path using `--with-cc-opt=` and `--with-ld-opt=` options:
 ```bash
 auto/configure --add-dynamic-module=<NJS_SRC_ROOT_DIR>/nginx \
-    --with-cc-opt="-I<QUICKJS_SRC_ROOT_DIR>" --with-ld-opt="-L<QUICKJS_SRC_ROOT_DIR>"
+    --with-cc-opt="-I <QUICKJS_SRC_ROOT_DIR>" --with-ld-opt="-L <QUICKJS_SRC_ROOT_DIR>"
 ```
 
 > [!WARNING]


### PR DESCRIPTION
### Proposed changes

This could be just me, but I originally didn't put a space between the flag and the path. I also thought that `<` was part of the entire command, so that it was supposed to be `-I</opt/quickjs>` which, obviously, doesn't work. This just clarifies and hopefully makes it more obvious that `<` just means "contained within is your var".