### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/njs_clang.h
+++ b/src/njs_clang.h
@@ -111,7 +111,7 @@ njs_leading_zeros64(uint64_t x)
 
     n = 0;
 
-    while ((x & 0x8000000000000000) == 0) {
+    while ((x & 0x8000000000000000ULL) == 0) {
         n++;
         x <<= 1;
     }

--- a/src/njs_value.c
+++ b/src/njs_value.c
@@ -8,7 +8,7 @@
 #include <njs_main.h>
 
 
-static njs_int_t njs_object_property_query(njs_vm_t *vm,
+njs_inline njs_int_t njs_object_property_query(njs_vm_t *vm,
     njs_property_query_t *pq, njs_object_t *object, uint32_t atom_id);
 static njs_int_t njs_array_property_query(njs_vm_t *vm,
     njs_property_query_t *pq, njs_array_t *array, uint32_t index,

--- a/src/njs_vmcode.c
+++ b/src/njs_vmcode.c
@@ -2591,7 +2591,7 @@ njs_function_frame_create(njs_vm_t *vm, njs_value_t *value,
 }
 
 
-inline njs_object_t *
+njs_object_t *
 njs_function_new_object(njs_vm_t *vm, njs_value_t *constructor)
 {
     njs_value_t     proto, bound;


### PR DESCRIPTION
* Inconsistent inline.
* Integer constant is too large for 'long' type (with mips -mabi=n32).

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [X] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works
- [X] If applicable, I have checked that any relevant tests pass after adding my changes
