### PR TITLE
fix:  Increase the NJS_MAX_STACK_SIZE

### DIFF
--- a/src/njs_vm.h
+++ b/src/njs_vm.h
@@ -8,7 +8,7 @@
 #define _NJS_VM_H_INCLUDED_
 
 
-#define NJS_MAX_STACK_SIZE       (64 * 1024)
+#define NJS_MAX_STACK_SIZE       (256 * 1024)
 
 
 typedef struct njs_frame_s            njs_frame_t;


### PR DESCRIPTION
### Proposed changes

close: https://github.com/nginx/njs/issues/939

quickjs-ng default STACK_SIZE_MAX  is 255? 

https://github.com/quickjs-ng/quickjs/blob/0191aea691e0ae37c35bc6737e73760506876148/libregexp.c#L55

```
#define STACK_SIZE_MAX 255
```

```
function f(n) {
  console.log(n)
  f(n + 1)
}

f(0)

// njs 925
```

v8-v7 test
```
Richards: 575
DeltaBlue: 453
Crypto: 983
RayTrace: 367
EarleyBoyer: 1113
RegExp: 58.1
Splay: 19.2
NavierStokes: 1065
----
Score: 325
```


### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
