### PR TITLE
Change: increasing the default stack size to 160k.

### DIFF
--- a/src/njs_vm.h
+++ b/src/njs_vm.h
@@ -8,7 +8,7 @@
 #define _NJS_VM_H_INCLUDED_
 
 
-#define NJS_MAX_STACK_SIZE       (64 * 1024)
+#define NJS_MAX_STACK_SIZE       (160 * 1024)
 
 
 typedef struct njs_frame_s            njs_frame_t;

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -21856,6 +21856,7 @@ njs_unit_test(njs_unit_test_t tests[], size_t num, njs_str_t *name,
         options.module = opts->module;
         options.unsafe = opts->unsafe;
         options.backtrace = opts->backtrace;
+        options.max_stack_size = 64 * 1024;
         options.addons = opts->externals ? njs_unit_test_addon_external_modules
                                          : njs_unit_test_addon_modules;
 
@@ -22008,6 +22009,7 @@ njs_interactive_test(njs_unit_test_t tests[], size_t num, njs_str_t *name,
         options.init = 1;
         options.interactive = 1;
         options.backtrace = 1;
+        options.max_stack_size = 64 * 1024;
         options.addons = opts->externals ? njs_unit_test_addon_external_modules
                                          : njs_unit_test_addon_modules;
 


### PR DESCRIPTION
This change allows EarleyBoyer benchmark from
arewefastyet/benchmarks/v8-v7 to pass with default settings.

Previous commit 5e9a6d5 (v0.7.9) reduced the stack size to prevent stack overflow when compiling with -O0 in computed goto mode, where native stack frames for njs_vmcode_interpreter() consume ~80KB each. To address this, we now set a lower maximum stack size specifically for unit tests.

This fixes #939 issue on Github.

