### PR TITLE
Modules: revert js_set checks introduced in d157f56.

### DIFF
--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -1540,6 +1540,9 @@ ngx_http_js_variable_set(ngx_http_request_t *r, ngx_http_variable_value_t *v,
     }
 
     if (rc == NGX_DECLINED) {
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                      "no \"js_import\" directives found for \"js_set\" \"%V\"",
+                      fname);
         v->not_found = 1;
         return NGX_OK;
     }
@@ -7691,14 +7694,10 @@ ngx_http_js_init_conf_vm(ngx_conf_t *cf, ngx_js_loc_conf_t *conf)
 static ngx_int_t
 ngx_http_js_init(ngx_conf_t *cf)
 {
-    ngx_uint_t                  i, found_issue;
-    ngx_js_set_t               *data;
-    ngx_hash_key_t             *key;
-    ngx_http_variable_t        *v;
-    ngx_js_periodic_t          *periodic;
-    ngx_js_loc_conf_t          *jlcf;
-    ngx_js_main_conf_t         *jmcf;
-    ngx_http_core_main_conf_t  *cmcf;
+    ngx_uint_t           i, found_issue;
+    ngx_js_periodic_t   *periodic;
+    ngx_js_loc_conf_t   *jlcf;
+    ngx_js_main_conf_t  *jmcf;
 
     ngx_http_next_header_filter = ngx_http_top_header_filter;
     ngx_http_top_header_filter = ngx_http_js_header_filter;
@@ -7724,21 +7723,6 @@ ngx_http_js_init(ngx_conf_t *cf)
             }
 
             found_issue = 1;
-        }
-
-        cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
-        key = cmcf->variables_keys->keys.elts;
-
-        for (i = 0; i < cmcf->variables_keys->keys.nelts; i++) {
-            v = key[i].value;
-            if (v->get_handler == ngx_http_js_variable_set) {
-                data = (ngx_js_set_t *) v->data;
-                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                              "no \"js_import\" directives found for "
-                              "\"js_set\" \"$%V\" \"%V\" in %s:%ui", &v->name,
-                              &data->fname, data->file_name, data->line);
-                found_issue = 1;
-            }
         }
 
         if (found_issue) {
@@ -7981,8 +7965,6 @@ ngx_http_js_set(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
 
     data->fname = value[2];
     data->flags = 0;
-    data->file_name = cf->conf_file->file.name.data;
-    data->line = cf->conf_file->line;
 
     if (v->get_handler == ngx_http_js_variable_set) {
         prev = (ngx_js_set_t *) v->data;

--- a/nginx/ngx_js.h
+++ b/nginx/ngx_js.h
@@ -188,8 +188,6 @@ struct ngx_js_loc_conf_s {
 typedef struct {
     ngx_str_t    fname;
     unsigned     flags;
-    u_char      *file_name;
-    ngx_uint_t   line;
 } ngx_js_set_t;
 
 

--- a/nginx/ngx_stream_js_module.c
+++ b/nginx/ngx_stream_js_module.c
@@ -1068,6 +1068,9 @@ ngx_stream_js_variable_set(ngx_stream_session_t *s,
     }
 
     if (rc == NGX_DECLINED) {
+        ngx_log_error(NGX_LOG_WARN, s->connection->log, 0,
+                      "no \"js_import\" directives found for \"js_set\" \"%V\"",
+                      fname);
         v->not_found = 1;
         return NGX_OK;
     }
@@ -3430,8 +3433,6 @@ ngx_stream_js_set(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
     }
 
     data->fname = value[2];
-    data->file_name = cf->conf_file->file.name.data;
-    data->line = cf->conf_file->line;
 
     if (v->get_handler == ngx_stream_js_variable_set) {
         prev = (ngx_js_set_t *) v->data;
@@ -3619,9 +3620,6 @@ ngx_stream_js_init(ngx_conf_t *cf)
 {
     ngx_uint_t                   i;
     ngx_flag_t                   found_issue;
-    ngx_js_set_t                *data;
-    ngx_hash_key_t              *key;
-    ngx_stream_variable_t       *v;
     ngx_js_periodic_t           *periodic;
     ngx_js_loc_conf_t           *jlcf;
     ngx_js_main_conf_t          *jmcf;
@@ -3665,20 +3663,6 @@ ngx_stream_js_init(ngx_conf_t *cf)
             }
 
             found_issue = 1;
-        }
-
-        key = cmcf->variables_keys->keys.elts;
-
-        for (i = 0; i < cmcf->variables_keys->keys.nelts; i++) {
-            v = key[i].value;
-            if (v->get_handler == ngx_stream_js_variable_set) {
-                data = (ngx_js_set_t *) v->data;
-                ngx_log_error(NGX_LOG_EMERG, cf->log, 0,
-                              "no \"js_import\" directives found for "
-                              "\"js_set\" \"$%V\" \"%V\" in %s:%ui", &v->name,
-                              &data->fname, data->file_name, data->line);
-                found_issue = 1;
-            }
         }
 
         if (found_issue) {

--- a/nginx/t/js_variables_no_function.t
+++ b/nginx/t/js_variables_no_function.t
@@ -1,0 +1,72 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) Nginx, Inc.
+
+# Tests for http njs module, setting nginx variables, no function.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http rewrite/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_set $no_function   test.variable;
+
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /no_function {
+            return 200 "NO FUNCTION:$no_function";
+        }
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    export default {};
+
+EOF
+
+$t->try_run('no njs')->plan(2);
+
+###############################################################################
+
+like(http_get('/no_function'), qr/NO FUNCTION:/,
+	'js_set without function is empty');
+
+$t->stop();
+
+ok(index($t->read_file('error.log'),
+	'js function "test.variable" not found') > 0,
+	'js_set without function logs error');
+
+###############################################################################

--- a/nginx/t/js_variables_no_import.t
+++ b/nginx/t/js_variables_no_import.t
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) Nginx, Inc.
+
+# Tests for http njs module, setting nginx variables, no js_import.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http rewrite/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_set $no_import   test.no_import;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /no_import {
+            return 200 "NO IMPORT:$no_import";
+        }
+    }
+}
+
+EOF
+
+$t->try_run('no njs')->plan(2);
+
+###############################################################################
+
+like(http_get('/no_import'), qr/NO IMPORT:/,
+	'js_set without js_import is empty');
+
+$t->stop();
+
+ok(index($t->read_file('error.log'),
+	'no "js_import" directives found for "js_set" "test.no_import"') > 0,
+	'js_set without function logs error');
+
+###############################################################################

--- a/nginx/t/stream_js_variables_no_function.t
+++ b/nginx/t/stream_js_variables_no_function.t
@@ -1,0 +1,69 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) Nginx, Inc.
+
+# Tests for stream njs module, setting nginx variables, no function.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_return/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    %%TEST_GLOBALS_STREAM%%
+
+    js_set $no_function  test.variable;
+
+    js_import test.js;
+
+    server {
+        listen  127.0.0.1:8081;
+        return  "NO FUNCTION:$no_function";
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    export default {};
+
+EOF
+
+$t->try_run('no stream njs available')->plan(2);
+
+###############################################################################
+
+is(stream('127.0.0.1:' . port(8081))->read(), 'NO FUNCTION:',
+	'js_set without function is empty');
+
+$t->stop();
+
+ok(index($t->read_file('error.log'),
+	'js function "test.variable" not found') > 0,
+	'js_set without function logs error');
+
+###############################################################################

--- a/nginx/t/stream_js_variables_no_import.t
+++ b/nginx/t/stream_js_variables_no_import.t
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) Nginx, Inc.
+
+# Tests for stream njs module, setting nginx variables, no js import.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_return/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    %%TEST_GLOBALS_STREAM%%
+
+    js_set $no_import  test.variable;
+
+    server {
+        listen  127.0.0.1:8081;
+        return  "NO IMPORT:$no_import";
+    }
+}
+
+EOF
+
+$t->try_run('no stream njs available')->plan(2);
+
+###############################################################################
+
+is(stream('127.0.0.1:' . port(8081))->read(), 'NO IMPORT:',
+	'js_set without function is empty');
+
+$t->stop();
+
+ok(index($t->read_file('error.log'),
+	'no "js_import" directives found for "js_set" "test.variable"') > 0,
+	'js_set without js_import logs error');
+
+###############################################################################


### PR DESCRIPTION
d157f56 introduced, among other things, configure time checks for variables created using js_set directive. It turned out to be too strict. It rejected configurations where js_import is declared at server level or below and not at main level.

This reverts d157f56, but adds a log warning when js_import was not found.

