### PR TITLE
HTTP: fixed buffer_type inheritance in if blocks.

### DIFF
--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -8260,6 +8260,8 @@ ngx_http_js_create_loc_conf(ngx_conf_t *cf)
     conf->ssl_verify = NGX_CONF_UNSET;
     conf->ssl_verify_depth = NGX_CONF_UNSET;
 #endif
+    conf->buffer_type = NGX_CONF_UNSET_UINT;
+
     return conf;
 }
 


### PR DESCRIPTION
Previously, when js_body_filter was used inside an if block that evaluated to true, the data parameter received Buffer type instead of the expected String type. This happened because buffer_type field in ngx_http_js_loc_conf_t was not properly initialized, causing the configuration merge to fail when nginx created a new location context for if blocks.

This fixes #999 issue on Github.
