### PR TITLE
Types: fixed CipherAlgorithm and Pbkdf2Params

### DIFF
--- a/ts/njs_webcrypto.d.ts
+++ b/ts/njs_webcrypto.d.ts
@@ -24,7 +24,7 @@ type CipherAlgorithm =
     | RsaOaepParams
     | AesCtrParams
     | AesCbcParams
-    | AesCbcParams;
+    | AesGcmParams;
 
 type HashVariants = "SHA-256" | "SHA-384" | "SHA-512" | "SHA-1";
 
@@ -97,7 +97,7 @@ interface   Pbkdf2Params {
     name: "PBKDF2";
     hash: HashVariants;
     salt: NjsStringOrBuffer;
-    interations: number;
+    iterations: number;
 }
 
 interface   EcdhParams {


### PR DESCRIPTION
### Proposed changes

Fixed two type definitions in WebCrypto. `CipherAlgorithm` contained the `AesCbcParams` twice, but was missing `AesGcmParams`. `iterations` in `Pbkdf2Params` was misspelled.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
