### PR TITLE
Shell: fix fuzzer harness to add NULL termination

### DIFF
--- a/external/njs_shell.c
+++ b/external/njs_shell.c
@@ -847,20 +847,33 @@ njs_options_free(njs_opts_t *opts)
 int
 LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
+    u_char      *buf;
     njs_opts_t  opts;
 
     if (size == 0) {
         return 0;
     }
 
+    buf = malloc(size + 1);
+    if (buf == NULL) {
+        return 0;
+    }
+
+    memcpy(buf, data, size);
+    buf[size] = '\0';
+
     njs_memzero(&opts, sizeof(njs_opts_t));
 
     opts.file = (char *) "fuzzer";
-    opts.command.start = (u_char *) data;
+    opts.command.start = buf;
     opts.command.length = size;
     opts.suppress_stdout = 1;
 
-    return njs_main(&opts);
+    (void) njs_main(&opts);
+
+    free(buf);
+
+    return 0;
 }
 
 #endif


### PR DESCRIPTION
The LLVMFuzzerTestOneInput() was passing input directly from libFuzzer without NULL termination, violating the API contract expected by njs_atod() and other functions that assume NULL-terminated strings.

Added explicit NULL termination to match real-world usage paths (CLI, nginx) which always go through njs_read_file().

Guided-by: Dmitry Volyntsev <xeioexception@gmail.com>

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

