### PR TITLE
auto/cc: Use portable/POSIX 'command -v' instead of 'which'

### DIFF
--- a/auto/cc
+++ b/auto/cc
@@ -13,7 +13,7 @@ END
 # Allow error exit status.
 set +e
 
-if [ -z "$(which $CC)" ]; then
+if ! command -v "${CC}" >/dev/null; then
     echo
     echo $0: error: $CC not found.
     echo


### PR DESCRIPTION
'which' is not a portable utility as it is not specified by POSIX. Since auto/cc is already a shell script, use the more direct and portable 'command' builtin to detect $CC.

There are two bugs linked here. The first one is a downstream report of this issue. The second one is more general information on why 'which' usage is an issue and should be avoided.

Bug: https://bugs.gentoo.org/969288
Bug: https://bugs.gentoo.org/646588

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
