### PR TITLE
Parser: fixed buffer underflow in njs_parser_error().

### DIFF
--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -9223,7 +9223,7 @@ njs_parser_error(njs_vm_t *vm, njs_object_type_t type, njs_str_t *file,
     width = njs_length(" in ") + file->length + NJS_INT_T_LEN;
 
     if (p > end - width) {
-        p = end - width;
+        p = njs_max(msg, end - width);
     }
 
     if (file->length != 0 && !vm->options.quiet) {


### PR DESCRIPTION
Previously, if the formatted error message length (width) exceeded the buffer size (NJS_MAX_ERROR_STR), the pointer calculation 'end - width' resulted in a memory address before the start of the 'msg' buffer. This caused a buffer underflow when writing to the pointer.

This change clamps the pointer to the start of the buffer using njs_max(), ensuring that memory writes remain within bounds.

Fixes #1005

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes

