### PR TITLE
Modules: suppressed slab log_nomem for evict shared dict zones.

### DIFF
--- a/nginx/ngx_js_shared_dict.c
+++ b/nginx/ngx_js_shared_dict.c
@@ -1302,7 +1302,9 @@ ngx_js_dict_alloc(ngx_js_dict_t *dict, size_t n)
 {
     void  *p;
 
+    dict->shpool->log_nomem = !dict->evict;
     p = ngx_slab_alloc_locked(dict->shpool, n);
+    dict->shpool->log_nomem = 1;
 
     if (p == NULL && dict->evict) {
         ngx_js_dict_evict(dict, 16);


### PR DESCRIPTION
When evict is enabled, memory allocation failures are expected and handled by evicting old entries.  The slab allocator's "no memory" log messages are now suppressed for such zones.
