### PR TITLE
ci: pin called workflow to full commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   buildbot:
-    uses: nginx/ci-self-hosted/.github/workflows/njs-buildbot.yml@main
+    uses: nginx/ci-self-hosted/.github/workflows/njs-buildbot.yml@a18ba87ce844172e745b83b6bcfed902c5bbe039 # main


### PR DESCRIPTION
## Summary

Pin reusable workflow ref from mutable branch name (`@main`) to a full commit SHA to prevent supply-chain attacks.

## Changes

| File | Before | After |
|------|--------|-------|
| `.github/workflows/ci.yml` | `nginx/ci-self-hosted/.github/workflows/njs-buildbot.yml@main` | `@a18ba87ce844172e745b83b6bcfed902c5bbe039 # main` |

Pinned to the current HEAD of `nginx/ci-self-hosted@main` — no behavioral change, only supply-chain hardening.