### PR TITLE
Modules: fixed loading of the built-in "crypto" module.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+Changes with njs 0.9.8                                       23 Apr 2026
+
+    nginx modules:
+
+    *) Bugfix: fixed loading of the built-in "crypto" module.
+       The issue was introduced in 3185ce81 (0.9.7).
+
 Changes with njs 0.9.7                                       21 Apr 2026
 
     nginx modules:

--- a/nginx/config
+++ b/nginx/config
@@ -8,6 +8,7 @@ NJS_QUICKJS=${NJS_QUICKJS:-YES}
 NJS_DEPS="$ngx_addon_dir/ngx_js.h \
     $ngx_addon_dir/ngx_js_http.h \
     $ngx_addon_dir/ngx_js_fetch.h \
+    $ngx_addon_dir/ngx_js_modules.h \
     $ngx_addon_dir/ngx_js_shared_dict.h"
 NJS_SRCS="$ngx_addon_dir/ngx_js.c \
     $ngx_addon_dir/ngx_js_http.c \

--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -10,6 +10,7 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 #include "ngx_js.h"
+#include "ngx_js_modules.h"
 
 
 typedef struct {
@@ -1072,22 +1073,7 @@ njs_module_t  ngx_js_http_module = {
 
 
 njs_module_t *njs_http_js_addon_modules[] = {
-    /*
-     * Shared addons should be in the same order and the same positions
-     * in all nginx modules.
-     */
-    &ngx_js_ngx_module,
-    &ngx_js_fetch_module,
-    &ngx_js_shared_dict_module,
-#ifdef NJS_HAVE_OPENSSL
-    &njs_webcrypto_module,
-#endif
-#ifdef NJS_HAVE_XML
-    &njs_xml_module,
-#endif
-#ifdef NJS_HAVE_ZLIB
-    &njs_zlib_module,
-#endif
+    NGX_JS_NJS_ADDON_MODULES
     &ngx_js_http_module,
     NULL,
 };
@@ -1217,24 +1203,7 @@ static JSClassDef ngx_http_qjs_headers_out_class = {
 
 
 qjs_module_t *njs_http_qjs_addon_modules[] = {
-    &ngx_qjs_ngx_module,
-    &ngx_qjs_ngx_shared_dict_module,
-#ifdef NJS_HAVE_QUICKJS
-    &ngx_qjs_ngx_fetch_module,
-#endif
-    /*
-     * Shared addons should be in the same order and the same positions
-     * in all nginx modules.
-     */
-#ifdef NJS_HAVE_OPENSSL
-    &qjs_webcrypto_module,
-#endif
-#ifdef NJS_HAVE_XML
-    &qjs_xml_module,
-#endif
-#ifdef NJS_HAVE_ZLIB
-    &qjs_zlib_module,
-#endif
+    NGX_JS_QJS_ADDON_MODULES
     NULL,
 };
 

--- a/nginx/ngx_js.h
+++ b/nginx/ngx_js.h
@@ -434,9 +434,6 @@ JSValue ngx_qjs_ext_fetch(JSContext *cx, JSValueConst this_val, int argc,
 #define ngx_qjs_main_conf(cx)                                                \
     ((ngx_js_main_conf_t *) ngx_qjs_meta(cx, NGX_JS_EXTERNAL_MAIN_CONF))
 
-extern qjs_module_t  qjs_webcrypto_module;
-extern qjs_module_t  qjs_xml_module;
-extern qjs_module_t  qjs_zlib_module;
 extern qjs_module_t  ngx_qjs_ngx_module;
 extern qjs_module_t  ngx_qjs_ngx_shared_dict_module;
 extern qjs_module_t  ngx_qjs_ngx_fetch_module;
@@ -491,9 +488,6 @@ void *ngx_js_queue_pop(ngx_js_queue_t *queue);
 
 
 extern njs_module_t  ngx_js_ngx_module;
-extern njs_module_t  njs_webcrypto_module;
-extern njs_module_t  njs_xml_module;
-extern njs_module_t  njs_zlib_module;
 
 
 #include "ngx_js_fetch.h"

--- a/nginx/ngx_js_modules.h
+++ b/nginx/ngx_js_modules.h
@@ -1,0 +1,88 @@
+
+/*
+ * Copyright (C) Dmitry Volyntsev
+ * Copyright (C) F5, Inc.
+ */
+
+
+#ifndef _NGX_JS_MODULES_H_INCLUDED_
+#define _NGX_JS_MODULES_H_INCLUDED_
+
+
+/*
+ * Shared addon module list registered by the HTTP and Stream nginx js
+ * modules.  When adding a new conditional addon, declare it here under the
+ * matching NJS_HAVE_* guard and extend the corresponding NGX_JS_NJS_ADDONS_*
+ * or NGX_JS_QJS_ADDONS_* fragment.
+ */
+
+
+#ifdef NJS_HAVE_OPENSSL
+extern njs_module_t  njs_crypto_module;
+extern njs_module_t  njs_webcrypto_module;
+#define NGX_JS_NJS_ADDONS_OPENSSL   &njs_crypto_module, &njs_webcrypto_module,
+#else
+#define NGX_JS_NJS_ADDONS_OPENSSL
+#endif
+
+#ifdef NJS_HAVE_XML
+extern njs_module_t  njs_xml_module;
+#define NGX_JS_NJS_ADDONS_XML       &njs_xml_module,
+#else
+#define NGX_JS_NJS_ADDONS_XML
+#endif
+
+#ifdef NJS_HAVE_ZLIB
+extern njs_module_t  njs_zlib_module;
+#define NGX_JS_NJS_ADDONS_ZLIB      &njs_zlib_module,
+#else
+#define NGX_JS_NJS_ADDONS_ZLIB
+#endif
+
+
+#define NGX_JS_NJS_ADDON_MODULES                                             \
+    &ngx_js_ngx_module,                                                      \
+    &ngx_js_fetch_module,                                                    \
+    &ngx_js_shared_dict_module,                                              \
+    NGX_JS_NJS_ADDONS_OPENSSL                                                \
+    NGX_JS_NJS_ADDONS_XML                                                    \
+    NGX_JS_NJS_ADDONS_ZLIB
+
+
+#if (NJS_HAVE_QUICKJS)
+
+#ifdef NJS_HAVE_OPENSSL
+extern qjs_module_t  qjs_crypto_module;
+extern qjs_module_t  qjs_webcrypto_module;
+#define NGX_JS_QJS_ADDONS_OPENSSL   &qjs_crypto_module, &qjs_webcrypto_module,
+#else
+#define NGX_JS_QJS_ADDONS_OPENSSL
+#endif
+
+#ifdef NJS_HAVE_XML
+extern qjs_module_t  qjs_xml_module;
+#define NGX_JS_QJS_ADDONS_XML       &qjs_xml_module,
+#else
+#define NGX_JS_QJS_ADDONS_XML
+#endif
+
+#ifdef NJS_HAVE_ZLIB
+extern qjs_module_t  qjs_zlib_module;
+#define NGX_JS_QJS_ADDONS_ZLIB      &qjs_zlib_module,
+#else
+#define NGX_JS_QJS_ADDONS_ZLIB
+#endif
+
+
+#define NGX_JS_QJS_ADDON_MODULES                                             \
+    &ngx_qjs_ngx_module,                                                     \
+    &ngx_qjs_ngx_shared_dict_module,                                         \
+    &ngx_qjs_ngx_fetch_module,                                               \
+    NGX_JS_QJS_ADDONS_OPENSSL                                                \
+    NGX_JS_QJS_ADDONS_XML                                                    \
+    NGX_JS_QJS_ADDONS_ZLIB
+
+#endif /* NJS_HAVE_QUICKJS */
+
+
+#endif /* _NGX_JS_MODULES_H_INCLUDED_ */

--- a/nginx/ngx_stream_js_module.c
+++ b/nginx/ngx_stream_js_module.c
@@ -10,6 +10,7 @@
 #include <ngx_core.h>
 #include <ngx_stream.h>
 #include "ngx_js.h"
+#include "ngx_js_modules.h"
 
 
 typedef struct ngx_stream_js_ctx_s  ngx_stream_js_ctx_t;
@@ -809,22 +810,7 @@ njs_module_t  ngx_js_stream_module = {
 
 
 njs_module_t *njs_stream_js_addon_modules[] = {
-    /*
-     * Shared addons should be in the same order and the same positions
-     * in all nginx modules.
-     */
-    &ngx_js_ngx_module,
-    &ngx_js_fetch_module,
-    &ngx_js_shared_dict_module,
-#ifdef NJS_HAVE_OPENSSL
-    &njs_webcrypto_module,
-#endif
-#ifdef NJS_HAVE_XML
-    &njs_xml_module,
-#endif
-#ifdef NJS_HAVE_ZLIB
-    &njs_zlib_module,
-#endif
+    NGX_JS_NJS_ADDON_MODULES
     &ngx_js_stream_module,
     NULL,
 };
@@ -906,22 +892,7 @@ static JSClassDef ngx_stream_qjs_variables_class = {
 
 
 qjs_module_t *njs_stream_qjs_addon_modules[] = {
-    &ngx_qjs_ngx_module,
-    &ngx_qjs_ngx_shared_dict_module,
-    &ngx_qjs_ngx_fetch_module,
-    /*
-     * Shared addons should be in the same order and the same positions
-     * in all nginx modules.
-     */
-#ifdef NJS_HAVE_OPENSSL
-    &qjs_webcrypto_module,
-#endif
-#ifdef NJS_HAVE_XML
-    &qjs_xml_module,
-#endif
-#ifdef NJS_HAVE_ZLIB
-    &qjs_zlib_module,
-#endif
+    NGX_JS_QJS_ADDON_MODULES
     NULL,
 };
 

--- a/nginx/t/js_crypto.t
+++ b/nginx/t/js_crypto.t
@@ -1,0 +1,85 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) F5, Inc.
+
+# Tests for http njs module, crypto module import.
+# Regression test for Github issue #1049.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /hash {
+            js_content test.hash;
+        }
+
+        location /hmac {
+            js_content test.hmac;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    import cr from 'crypto';
+
+    function hash(r) {
+        r.return(200,
+            cr.createHash('sha256').update('abc').digest('hex'));
+    }
+
+    function hmac(r) {
+        r.return(200,
+            cr.createHmac('sha256', 'key').update('message').digest('hex'));
+    }
+
+    export default {hash, hmac};
+EOF
+
+$t->try_run('no njs crypto module')->plan(2);
+
+###############################################################################
+
+like(http_get('/hash'),
+	qr/ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad/,
+	'crypto sha256 digest');
+
+like(http_get('/hmac'),
+	qr/6e9ef29b75fffc5b7abae527d58fdadb2fe42e7219011976917343065f58ed4a/,
+	'crypto hmac-sha256 digest');
+
+###############################################################################

--- a/nginx/t/stream_js_crypto.t
+++ b/nginx/t/stream_js_crypto.t
@@ -1,0 +1,70 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) F5, Inc.
+
+# Tests for stream njs module, crypto module import.
+# Regression test for Github issue #1049.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/stream stream_return/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+stream {
+    %%TEST_GLOBALS_STREAM%%
+
+    js_import test.js;
+
+    js_set $hash test.hash;
+
+    server {
+        listen  127.0.0.1:8081;
+        return  $hash;
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<EOF);
+    import cr from 'crypto';
+
+    function hash(s) {
+        return cr.createHash('sha256').update('abc').digest('hex');
+    }
+
+    export default {hash};
+EOF
+
+$t->try_run('no njs crypto module')->plan(1);
+
+###############################################################################
+
+like(stream('127.0.0.1:' . port(8081))->io('###'),
+	qr/ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad/,
+	'crypto sha256 digest');
+
+###############################################################################

--- a/src/njs.h
+++ b/src/njs.h
@@ -11,8 +11,8 @@
 
 #include <njs_auto_config.h>
 
-#define NJS_VERSION                 "0.9.7"
-#define NJS_VERSION_NUMBER          0x000907
+#define NJS_VERSION                 "0.9.8"
+#define NJS_VERSION_NUMBER          0x000908
 
 
 #include <string.h>


### PR DESCRIPTION
Since https://github.com/nginx/njs/commit/3185ce819be0eadbaea1b602c6aa72108fdc32cd (0.9.7), njs_crypto_module has been registered
conditionally in auto/modules under NJS_HAVE_OPENSSL.  libnjs.a is
built for the nginx module via nginx/config.make with
"./configure --no-openssl ...", so libnjs.a's njs_modules[] no
longer contains the crypto module.  The nginx addon lists
(njs_http_js_addon_modules[] and njs_stream_js_addon_modules[],
plus the qjs variants) were not updated accordingly, making
"import cr from 'crypto'" fail at nginx -t with ENOENT.

Added &njs_crypto_module and &qjs_crypto_module to the shared addon
list under the existing NJS_HAVE_OPENSSL guard, next to the webcrypto
entries.

While here, the near-identical addon arrays were factored into
shared macros in a new header nginx/ngx_js_modules.h, so adding a
future conditional addon needs a single edit instead of four.

This closes https://github.com/nginx/njs/issues/1049 issue on Github.