### PR TITLE
Fixed allocator mismatch in drain/drop.

### DIFF
--- a/src/njs_chb.c
+++ b/src/njs_chb.c
@@ -129,7 +129,10 @@ njs_chb_drain(njs_chb_t *chain, size_t drain)
         drain -= njs_chb_node_size(n);
         chain->nodes = n->next;
 
-        njs_mp_free(chain->pool, n);
+        if (chain->free != NULL) {
+            chain->free(chain->pool, n);
+        }
+
         n = chain->nodes;
     }
 
@@ -184,7 +187,11 @@ njs_chb_drop(njs_chb_t *chain, size_t drop)
 
     while (n != NULL) {
         next = n->next;
-        njs_mp_free(chain->pool, n);
+
+        if (chain->free != NULL) {
+            chain->free(chain->pool, n);
+        }
+
         n = next;
     }
 }


### PR DESCRIPTION
njs_chb_destroy() frees chain nodes through chain->free() and guards against a NULL free callback.  njs_chb_drain() and the tail-freeing path of njs_chb_drop() called njs_mp_free() directly, which is wrong for chains initialized with NJS_CHB_CTX_INIT() where chain->free is js_free(), and unsafe for NGX_CHB_CTX_INIT() chains where chain->free is NULL.

Both paths now route through chain->free() with the same NULL guard as njs_chb_destroy().
