### PR TITLE
Exceptions overhaul

### DIFF
--- a/external/njs_xml_module.c
+++ b/external/njs_xml_module.c
@@ -2022,7 +2022,7 @@ njs_xml_error(njs_vm_t *vm, njs_xml_doc_t *current, const char *fmt, ...)
                         err->int2);
     }
 
-    njs_vm_error(vm, "%*s", p - errstr, errstr);
+    njs_vm_syntax_error(vm, "%*s", p - errstr, errstr);
 }
 
 

--- a/external/qjs_fs_module.c
+++ b/external/qjs_fs_module.c
@@ -2399,7 +2399,7 @@ qjs_fs_stats_get_own_property(JSContext *cx, JSPropertyDescriptor *pdesc,
 
     st = JS_GetOpaque2(cx, obj, QJS_CORE_CLASS_ID_FS_STATS);
     if (st == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a Stats object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a Stats object");
         return -1;
     }
 

--- a/external/qjs_xml_module.c
+++ b/external/qjs_xml_module.c
@@ -384,7 +384,7 @@ qjs_xml_doc_get_own_property(JSContext *cx, JSPropertyDescriptor *pdesc,
 
     tree = JS_GetOpaque(obj, QJS_CORE_CLASS_ID_XML_DOC);
     if (tree == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not an XMLDoc");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not an XMLDoc");
         return -1;
     }
 
@@ -469,7 +469,7 @@ qjs_xml_doc_get_own_property_names(JSContext *cx, JSPropertyEnum **ptab,
 
     tree = JS_GetOpaque(obj, QJS_CORE_CLASS_ID_XML_DOC);
     if (tree == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not an XMLDoc");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not an XMLDoc");
         return -1;
     }
 
@@ -741,9 +741,9 @@ qjs_xml_node_tag_modify(JSContext *cx, JSValue obj, njs_str_t *name,
     }
 
     if (!JS_IsNullOrUndefined(setval)) {
-        JS_ThrowInternalError(cx, "XMLNode.$tag$xxx is not assignable, "
-                           "use addChild() or node.$tags = [node1, node2, ..] "
-                           "syntax");
+        JS_ThrowTypeError(cx, "XMLNode.$tag$xxx is not assignable, "
+                          "use addChild() or node.$tags = [node1, node2, ..] "
+                          "syntax");
         return -1;
     }
 
@@ -929,7 +929,7 @@ qjs_xml_node_get_own_property(JSContext *cx, JSPropertyDescriptor *pdesc,
 
     current = JS_GetOpaque(obj, QJS_CORE_CLASS_ID_XML_NODE);
     if (current == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not an XMLNode");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not an XMLNode");
         return -1;
     }
 
@@ -1173,7 +1173,7 @@ qjs_xml_node_get_own_property_names(JSContext *cx, JSPropertyEnum **ptab,
 
     tree = JS_GetOpaque(obj, QJS_CORE_CLASS_ID_XML_NODE);
     if (tree == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not an XMLNode");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not an XMLNode");
         return -1;
     }
 
@@ -1552,7 +1552,7 @@ qjs_xml_node(JSContext *cx, JSValueConst val, xmlDoc **doc)
     if (current == NULL) {
         tree = JS_GetOpaque(val, QJS_CORE_CLASS_ID_XML_DOC);
         if (tree == NULL) {
-            JS_ThrowInternalError(cx, "'this' is not XMLNode or XMLDoc");
+            JS_ThrowTypeError(cx, "value is not XMLNode or XMLDoc");
             return NULL;
         }
 
@@ -1611,7 +1611,7 @@ qjs_xml_attr_get_own_property(JSContext *cx, JSPropertyDescriptor *pdesc,
 
     current = JS_GetOpaque(obj, QJS_CORE_CLASS_ID_XML_ATTR);
     if (current == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not an XMLAttr");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not an XMLAttr");
         return -1;
     }
 
@@ -1675,7 +1675,7 @@ qjs_xml_attr_get_own_property_names(JSContext *cx, JSPropertyEnum **ptab,
 
     current = JS_GetOpaque(obj, QJS_CORE_CLASS_ID_XML_ATTR);
     if (current == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not an XMLAttr");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not an XMLAttr");
         return -1;
     }
 

--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -2983,12 +2983,14 @@ ngx_http_js_ext_send_header(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (ngx_http_set_content_type(r) != NGX_OK) {
+        njs_vm_internal_error(vm, "failed to set content type");
         return NJS_ERROR;
     }
 
     r->disable_not_modified = 1;
 
     if (ngx_http_send_header(r) == NGX_ERROR) {
+        njs_vm_internal_error(vm, "failed to send header");
         return NJS_ERROR;
     }
 
@@ -3037,6 +3039,7 @@ ngx_http_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
         b = ngx_calloc_buf(r->pool);
         if (b == NULL) {
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
 
@@ -3048,6 +3051,7 @@ ngx_http_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
         cl = ngx_alloc_chain_link(r->pool);
         if (cl == NULL) {
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
 
@@ -3060,6 +3064,7 @@ ngx_http_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     *ll = NULL;
 
     if (ngx_http_output_filter(r, out) == NGX_ERROR) {
+        njs_vm_internal_error(vm, "failed to send response");
         return NJS_ERROR;
     }
 
@@ -3217,6 +3222,7 @@ ngx_http_js_ext_finish(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (ngx_http_send_special(r, NGX_HTTP_LAST) == NGX_ERROR) {
+        njs_vm_internal_error(vm, "failed to send response");
         return NJS_ERROR;
     }
 

--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -2978,7 +2978,7 @@ ngx_http_js_ext_send_header(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -3014,14 +3014,14 @@ ngx_http_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
 
     if (ctx->filter) {
-        njs_vm_error(vm, "cannot send while in body filter");
+        njs_vm_type_error(vm, "cannot send while in body filter");
         return NJS_ERROR;
     }
 
@@ -3093,19 +3093,19 @@ ngx_http_js_ext_send_buffer(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
 
     if (!ctx->filter) {
-        njs_vm_error(vm, "cannot send buffer while not filtering");
+        njs_vm_type_error(vm, "cannot send buffer while not filtering");
         return NJS_ERROR;
     }
 
     if (ngx_js_string(vm, njs_arg(args, nargs, 1), &buffer) != NGX_OK) {
-        njs_vm_error(vm, "failed to get buffer arg");
+        njs_vm_type_error(vm, "failed to get buffer arg");
         return NJS_ERROR;
     }
 
@@ -3128,7 +3128,7 @@ ngx_http_js_ext_send_buffer(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     cl = ngx_chain_get_free_buf(r->pool, &ctx->free);
     if (cl == NULL) {
-        njs_vm_error(vm, "memory error");
+        njs_vm_memory_error(vm);
         return NJS_ERROR;
     }
 
@@ -3165,7 +3165,7 @@ ngx_http_js_ext_set_return_value(njs_vm_t *vm, njs_value_t *args,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -3188,14 +3188,14 @@ ngx_http_js_ext_done(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
 
     if (!ctx->filter) {
-        njs_vm_error(vm, "cannot set done while not filtering");
+        njs_vm_type_error(vm, "cannot set done while not filtering");
         return NJS_ERROR;
     }
 
@@ -3217,7 +3217,7 @@ ngx_http_js_ext_finish(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -3249,7 +3249,7 @@ ngx_http_js_ext_return(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -3258,7 +3258,7 @@ ngx_http_js_ext_return(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (status < 0 || status > 999) {
-        njs_vm_error(vm, "code is out of range");
+        njs_vm_range_error(vm, "code is out of range");
         return NJS_ERROR;
     }
 
@@ -3268,7 +3268,7 @@ ngx_http_js_ext_return(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         || !njs_value_is_null_or_undefined(njs_arg(args, nargs, 2)))
     {
         if (ngx_js_string(vm, njs_arg(args, nargs, 2), &text) != NGX_OK) {
-            njs_vm_error(vm, "failed to convert text");
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
 
@@ -3282,7 +3282,7 @@ ngx_http_js_ext_return(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         ctx->status = ngx_http_send_response(r, status, NULL, &cv);
 
         if (ctx->status == NGX_ERROR) {
-            njs_vm_error(vm, "failed to send response");
+            njs_vm_internal_error(vm, "failed to send response");
             return NJS_ERROR;
         }
 
@@ -3306,7 +3306,7 @@ ngx_http_js_ext_decline(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -3331,29 +3331,31 @@ ngx_http_js_ext_internal_redirect(njs_vm_t *vm, njs_value_t *args,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
     if (r->parent != NULL) {
-        njs_vm_error(vm, "internalRedirect cannot be called from a subrequest");
+        njs_vm_type_error(vm, "internalRedirect cannot be called from "
+                          "a subrequest");
         return NJS_ERROR;
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
 
     if (ctx->filter) {
-        njs_vm_error(vm, "internalRedirect cannot be called while filtering");
+        njs_vm_type_error(vm, "internalRedirect cannot be called while "
+                          "filtering");
         return NJS_ERROR;
     }
 
     if (ngx_js_string(vm, njs_arg(args, nargs, 1), &uri) != NGX_OK) {
-        njs_vm_error(vm, "failed to convert uri arg");
+        njs_vm_type_error(vm, "failed to convert uri arg");
         return NJS_ERROR;
     }
 
     if (uri.length == 0) {
-        njs_vm_error(vm, "uri is empty");
+        njs_vm_type_error(vm, "uri is empty");
         return NJS_ERROR;
     }
 
@@ -3744,7 +3746,7 @@ ngx_http_js_form_to_value(njs_vm_t *vm, ngx_http_request_t *r,
     }
 
     if (rc == NGX_JS_FORM_PARSE_ERROR) {
-        njs_vm_error(vm, "%V", &error);
+        njs_vm_type_error(vm, "%V", &error);
         return NJS_ERROR;
     }
 
@@ -3888,7 +3890,7 @@ ngx_http_js_ext_read_request_body(njs_vm_t *vm, njs_value_t *args,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -3912,7 +3914,7 @@ ngx_http_js_ext_read_request_body(njs_vm_t *vm, njs_value_t *args,
     }
 
     if (ctx->body_read_event) {
-        njs_vm_error(vm, "request body is already being read");
+        njs_vm_type_error(vm, "request body is already being read");
         return NJS_ERROR;
     }
 
@@ -3937,7 +3939,7 @@ ngx_http_js_ext_read_request_body(njs_vm_t *vm, njs_value_t *args,
 resolve:
 
     if (ngx_http_js_collect_body(r, ctx) != NGX_OK) {
-        njs_vm_memory_error(vm);
+        njs_vm_internal_error(vm, "failed to read request body");
         return NJS_ERROR;
     }
 
@@ -3999,7 +4001,7 @@ ngx_http_js_ext_read_request_form(njs_vm_t *vm, njs_value_t *args,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -4017,7 +4019,7 @@ ngx_http_js_ext_read_request_form(njs_vm_t *vm, njs_value_t *args,
     }
 
     if (ctx->body_read_event) {
-        njs_vm_error(vm, "request body is already being read");
+        njs_vm_type_error(vm, "request body is already being read");
         return NJS_ERROR;
     }
 
@@ -4051,7 +4053,7 @@ ngx_http_js_ext_read_request_form(njs_vm_t *vm, njs_value_t *args,
 resolve:
 
     if (ngx_http_js_collect_body(r, ctx) != NGX_OK) {
-        njs_vm_memory_error(vm);
+        njs_vm_internal_error(vm, "failed to read request body");
         return NJS_ERROR;
     }
 
@@ -4073,7 +4075,7 @@ ngx_http_js_ext_request_form_get(njs_vm_t *vm, njs_value_t *args,
     form = njs_vm_external(vm, ngx_http_js_request_form_proto_id,
                            njs_argument(args, 0));
     if (form == NULL) {
-        njs_vm_error(vm, "\"this\" is not a RequestForm");
+        njs_vm_type_error(vm, "\"this\" is not a RequestForm");
         return NJS_ERROR;
     }
 
@@ -4135,7 +4137,7 @@ ngx_http_js_ext_request_form_has(njs_vm_t *vm, njs_value_t *args,
     form = njs_vm_external(vm, ngx_http_js_request_form_proto_id,
                            njs_argument(args, 0));
     if (form == NULL) {
-        njs_vm_error(vm, "\"this\" is not a RequestForm");
+        njs_vm_type_error(vm, "\"this\" is not a RequestForm");
         return NJS_ERROR;
     }
 
@@ -4177,13 +4179,13 @@ ngx_http_js_ext_request_form_for_each(njs_vm_t *vm, njs_value_t *args,
 
     form = njs_vm_external(vm, ngx_http_js_request_form_proto_id, this);
     if (form == NULL) {
-        njs_vm_error(vm, "\"this\" is not a RequestForm");
+        njs_vm_type_error(vm, "\"this\" is not a RequestForm");
         return NJS_ERROR;
     }
 
     callback = njs_arg(args, nargs, 1);
     if (!njs_value_is_function(callback)) {
-        njs_vm_error(vm, "\"callback\" is not a function");
+        njs_vm_type_error(vm, "\"callback\" is not a function");
         return NJS_ERROR;
     }
 
@@ -4261,7 +4263,7 @@ ngx_http_js_ext_request_form_has_files(njs_vm_t *vm, njs_value_t *args,
     form = njs_vm_external(vm, ngx_http_js_request_form_proto_id,
                            njs_argument(args, 0));
     if (form == NULL) {
-        njs_vm_error(vm, "\"this\" is not a RequestForm");
+        njs_vm_type_error(vm, "\"this\" is not a RequestForm");
         return NJS_ERROR;
     }
 
@@ -4490,7 +4492,7 @@ ngx_http_js_ext_js_var_names(njs_vm_t *vm, njs_value_t *args,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -4634,7 +4636,7 @@ ngx_http_js_request_variables(njs_vm_t *vm, njs_object_prop_t *prop,
     v = ngx_hash_find(&cmcf->variables_hash, key, name.data, val.length);
 
     if (v == NULL) {
-        njs_vm_error(vm, "variable not found");
+        njs_vm_type_error(vm, "variable not found");
         return NJS_ERROR;
     }
 
@@ -4645,7 +4647,7 @@ ngx_http_js_request_variables(njs_vm_t *vm, njs_object_prop_t *prop,
     if (v->set_handler != NULL) {
         vv = ngx_pcalloc(r->pool, sizeof(ngx_http_variable_value_t));
         if (vv == NULL) {
-            njs_vm_error(vm, "internal error");
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
 
@@ -4660,7 +4662,7 @@ ngx_http_js_request_variables(njs_vm_t *vm, njs_object_prop_t *prop,
     }
 
     if (!(v->flags & NGX_HTTP_VAR_INDEXED)) {
-        njs_vm_error(vm, "variable is not writable");
+        njs_vm_type_error(vm, "variable is not writable");
         return NJS_ERROR;
     }
 
@@ -4672,7 +4674,7 @@ ngx_http_js_request_variables(njs_vm_t *vm, njs_object_prop_t *prop,
     vv->data = ngx_pnalloc(r->pool, s.length);
     if (vv->data == NULL) {
         vv->valid = 0;
-        njs_vm_error(vm, "internal error");
+        njs_vm_memory_error(vm);
         return NJS_ERROR;
     }
 
@@ -4742,25 +4744,25 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     r = njs_vm_external(vm, ngx_http_js_request_proto_id,
                         njs_argument(args, 0));
     if (r == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
 
     if (r->subrequest_in_memory) {
-        njs_vm_error(vm, "subrequest can only be created for "
-                         "the primary request");
+        njs_vm_type_error(vm, "subrequest can only be created for "
+                          "the primary request");
         return NJS_ERROR;
     }
 
     if (ngx_js_string(vm, njs_arg(args, nargs, 1), &uri_arg) != NGX_OK) {
-        njs_vm_error(vm, "failed to convert uri arg");
+        njs_vm_type_error(vm, "failed to convert uri arg");
         return NJS_ERROR;
     }
 
     if (uri_arg.length == 0) {
-        njs_vm_error(vm, "uri is empty");
+        njs_vm_type_error(vm, "uri is empty");
         return NJS_ERROR;
     }
 
@@ -4779,7 +4781,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     if (njs_value_is_string(arg)) {
         if (ngx_js_string(vm, arg, &args_arg) != NJS_OK) {
-            njs_vm_error(vm, "failed to convert args");
+            njs_vm_type_error(vm, "failed to convert args");
             return NJS_ERROR;
         }
 
@@ -4790,7 +4792,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         options = arg;
 
     } else if (!njs_value_is_null_or_undefined(arg)) {
-        njs_vm_error(vm, "failed to convert args");
+        njs_vm_type_error(vm, "failed to convert args");
         return NJS_ERROR;
     }
 
@@ -4798,7 +4800,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         value = njs_vm_object_prop(vm, options, &args_key, &lvalue);
         if (value != NULL) {
             if (ngx_js_string(vm, value, &args_arg) != NGX_OK) {
-                njs_vm_error(vm, "failed to convert options.args");
+                njs_vm_type_error(vm, "failed to convert options.args");
                 return NJS_ERROR;
             }
         }
@@ -4811,7 +4813,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         value = njs_vm_object_prop(vm, options, &method_key, &lvalue);
         if (value != NULL) {
             if (ngx_js_string(vm, value, &method_name) != NGX_OK) {
-                njs_vm_error(vm, "failed to convert options.method");
+                njs_vm_type_error(vm, "failed to convert options.method");
                 return NJS_ERROR;
             }
 
@@ -4832,7 +4834,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         value = njs_vm_object_prop(vm, options, &body_key, &lvalue);
         if (value != NULL) {
             if (ngx_js_string(vm, value, &body_arg) != NGX_OK) {
-                njs_vm_error(vm, "failed to convert options.body");
+                njs_vm_type_error(vm, "failed to convert options.body");
                 return NJS_ERROR;
             }
 
@@ -4841,7 +4843,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (ngx_http_js_parse_unsafe_uri(r, &uri_arg, &args_arg) != NGX_OK) {
-        njs_vm_error(vm, "unsafe uri");
+        njs_vm_type_error(vm, "unsafe uri");
         return NJS_ERROR;
     }
 
@@ -4849,7 +4851,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     if (callback == NULL && !njs_value_is_undefined(arg)) {
         if (!njs_value_is_function(arg)) {
-            njs_vm_error(vm, "callback is not a function");
+            njs_vm_type_error(vm, "callback is not a function");
             return NJS_ERROR;
 
         } else {
@@ -4858,7 +4860,8 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (detached && callback != NULL) {
-        njs_vm_error(vm, "detached flag and callback are mutually exclusive");
+        njs_vm_type_error(vm, "detached flag and callback are mutually "
+                          "exclusive");
         return NJS_ERROR;
     }
 
@@ -4916,7 +4919,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     if (ngx_http_subrequest(r, &uri, rargs.len ? &rargs : NULL, &sr, ps, flags)
         != NGX_OK)
     {
-        njs_vm_error(vm, "subrequest creation failed");
+        njs_vm_internal_error(vm, "subrequest creation failed");
         return NJS_ERROR;
     }
 
@@ -4971,7 +4974,7 @@ ngx_http_js_ext_subrequest(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
 memory_error:
 
-    njs_vm_error(vm, "internal error");
+    njs_vm_memory_error(vm);
 
     return NJS_ERROR;
 }
@@ -5575,8 +5578,8 @@ ngx_http_js_content_length(njs_vm_t *vm, ngx_http_request_t *r,
             n = ngx_atoi(h->value.data, h->value.len);
             if (n == NGX_ERROR) {
                 h->hash = 0;
-                njs_vm_error(vm, "failed converting argument "
-                             "to positive integer");
+                njs_vm_type_error(vm, "failed converting argument "
+                                  "to positive integer");
                 return NJS_ERROR;
             }
 
@@ -6159,7 +6162,7 @@ ngx_http_qjs_ext_args(JSContext *cx, JSValueConst this_val)
 
     req = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_REQUEST);
     if (req == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     if (!JS_IsUndefined(req->args)) {
@@ -6297,7 +6300,7 @@ ngx_http_qjs_ext_done(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
@@ -6321,7 +6324,7 @@ ngx_http_qjs_ext_finish(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     if (ngx_http_send_special(r, NGX_HTTP_LAST) == NGX_ERROR) {
@@ -6344,7 +6347,7 @@ ngx_http_qjs_ext_headers_in(JSContext *cx, JSValueConst this_val)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     obj = JS_NewObjectProtoClass(cx, JS_NULL, NGX_QJS_CLASS_ID_HTTP_HEADERS_IN);
@@ -6363,7 +6366,7 @@ ngx_http_qjs_ext_headers_out(JSContext *cx, JSValueConst this_val)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     obj = JS_NewObjectProtoClass(cx, JS_NULL,
@@ -6383,7 +6386,7 @@ ngx_http_qjs_ext_http_version(JSContext *cx, JSValueConst this_val)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     switch (r->http_version) {
@@ -6425,7 +6428,7 @@ ngx_http_qjs_ext_internal(JSContext *cx, JSValueConst this_val)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     return JS_NewBool(cx, r->internal);
@@ -6441,7 +6444,7 @@ ngx_http_qjs_ext_internal_redirect(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     if (r->parent != NULL) {
@@ -6476,7 +6479,7 @@ ngx_http_qjs_ext_log(JSContext *cx, JSValueConst this_val, int argc,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     for (n = 0; n < argc; n++) {
@@ -6503,7 +6506,7 @@ ngx_http_qjs_ext_periodic_variables(JSContext *cx,
 
     req = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_PERIODIC);
     if (req == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a periodic object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a periodic object");
     }
 
     obj = JS_NewObjectProtoClass(cx, JS_NULL, NGX_QJS_CLASS_ID_HTTP_VARS);
@@ -6526,7 +6529,7 @@ ngx_http_qjs_ext_parent(JSContext *cx, JSValueConst this_val)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     ctx = r->parent ? ngx_http_get_module_ctx(r->parent, ngx_http_js_module)
@@ -6548,7 +6551,7 @@ ngx_http_qjs_ext_remote_address(JSContext *cx, JSValueConst this_val)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     c = r->connection;
@@ -6570,7 +6573,7 @@ ngx_http_qjs_ext_response_body(JSContext *cx, JSValueConst this_val, int type)
 
     req = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_REQUEST);
     if (req == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     buffer_type = ngx_js_buffer_type(type);
@@ -6622,7 +6625,7 @@ ngx_http_qjs_ext_request_body(JSContext *cx, JSValueConst this_val, int type)
 
     req = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_REQUEST);
     if (req == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     buffer_type = ngx_js_buffer_type(type);
@@ -6753,7 +6756,7 @@ ngx_http_qjs_ext_read_request_body(JSContext *cx, JSValueConst this_val,
 
     req = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_REQUEST);
     if (req == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     r = req->request;
@@ -6764,7 +6767,7 @@ ngx_http_qjs_ext_read_request_body(JSContext *cx, JSValueConst this_val,
     }
 
     if (ctx->body_read_event) {
-        return JS_ThrowInternalError(cx, "request body is already being read");
+        return JS_ThrowTypeError(cx, "request body is already being read");
     }
 
     event = ngx_pcalloc(r->pool, sizeof(ngx_qjs_event_t) + sizeof(JSValue) * 2);
@@ -6795,7 +6798,7 @@ ngx_http_qjs_ext_read_request_body(JSContext *cx, JSValueConst this_val,
 resolve:
 
     if (ngx_http_js_collect_body(r, ctx) != NGX_OK) {
-        return JS_ThrowOutOfMemory(cx);
+        return JS_ThrowInternalError(cx, "failed to read request body");
     }
 
     return ngx_http_qjs_body_to_value(cx, ctx, (ngx_uint_t) magic);
@@ -6882,7 +6885,7 @@ ngx_http_qjs_form_to_value(JSContext *cx, ngx_http_request_t *r,
     }
 
     if (rc == NGX_JS_FORM_PARSE_ERROR) {
-        return JS_ThrowInternalError(cx, "%.*s", (int) error.len, error.data);
+        return JS_ThrowTypeError(cx, "%.*s", (int) error.len, error.data);
     }
 
     return JS_ThrowOutOfMemory(cx);
@@ -6902,7 +6905,7 @@ ngx_http_qjs_ext_read_request_form(JSContext *cx, JSValueConst this_val,
 
     req = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_REQUEST);
     if (req == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     if (ngx_http_qjs_request_form_max_keys(cx, argv[0], &max_keys) != NGX_OK) {
@@ -6917,7 +6920,7 @@ ngx_http_qjs_ext_read_request_form(JSContext *cx, JSValueConst this_val,
     }
 
     if (ctx->body_read_event) {
-        return JS_ThrowInternalError(cx, "request body is already being read");
+        return JS_ThrowTypeError(cx, "request body is already being read");
     }
 
     event = ngx_pcalloc(r->pool, sizeof(ngx_qjs_event_t) + sizeof(JSValue) * 2);
@@ -6949,7 +6952,7 @@ ngx_http_qjs_ext_read_request_form(JSContext *cx, JSValueConst this_val,
 resolve:
 
     if (ngx_http_js_collect_body(r, ctx) != NGX_OK) {
-        return JS_ThrowOutOfMemory(cx);
+        return JS_ThrowInternalError(cx, "failed to read request body");
     }
 
     return ngx_http_qjs_form_to_value(cx, r, ctx, max_keys);
@@ -6969,7 +6972,7 @@ ngx_http_qjs_ext_request_form_get(JSContext *cx, JSValueConst this_val,
 
     form = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_FORM);
     if (form == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a RequestForm");
+        return JS_ThrowTypeError(cx, "\"this\" is not a RequestForm");
     }
 
     name = JS_ToCStringLen(cx, &name_len, argv[0]);
@@ -7042,7 +7045,7 @@ ngx_http_qjs_ext_request_form_has(JSContext *cx, JSValueConst this_val,
 
     form = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_FORM);
     if (form == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a RequestForm");
+        return JS_ThrowTypeError(cx, "\"this\" is not a RequestForm");
     }
 
     name = JS_ToCStringLen(cx, &name_len, argv[0]);
@@ -7078,7 +7081,7 @@ ngx_http_qjs_ext_request_form_for_each(JSContext *cx, JSValueConst this_val,
 
     form = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_FORM);
     if (form == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a RequestForm");
+        return JS_ThrowTypeError(cx, "\"this\" is not a RequestForm");
     }
 
     if (!JS_IsFunction(cx, argv[0])) {
@@ -7157,7 +7160,7 @@ ngx_http_qjs_ext_request_form_has_files(JSContext *cx, JSValueConst this_val,
 
     form = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_HTTP_FORM);
     if (form == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a RequestForm");
+        return JS_ThrowTypeError(cx, "\"this\" is not a RequestForm");
     }
 
     return JS_NewBool(cx, form->has_files);
@@ -7189,7 +7192,7 @@ ngx_http_qjs_ext_return(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     if (ngx_qjs_integer(cx, argv[0], &status) != NGX_OK) {
@@ -7217,7 +7220,7 @@ ngx_http_qjs_ext_return(JSContext *cx, JSValueConst this_val,
         ctx->status = ngx_http_send_response(r, status, NULL, &cv);
 
         if (ctx->status == NGX_ERROR) {
-            return JS_ThrowTypeError(cx, "failed to send response");
+            return JS_ThrowInternalError(cx, "failed to send response");
         }
 
     } else {
@@ -7237,7 +7240,7 @@ ngx_http_qjs_ext_decline(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
@@ -7255,7 +7258,7 @@ ngx_http_qjs_ext_status_get(JSContext *cx, JSValueConst this_val)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     return JS_NewInt32(cx, r->headers_out.status);
@@ -7271,7 +7274,7 @@ ngx_http_qjs_ext_status_set(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     if (ngx_qjs_integer(cx, value, &n) != NGX_OK) {
@@ -7293,7 +7296,7 @@ ngx_http_qjs_ext_string(JSContext *cx, JSValueConst this_val, int offset)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     field = (ngx_str_t *) ((u_char *) r + offset);
@@ -7315,7 +7318,7 @@ ngx_http_qjs_ext_send(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
@@ -7338,7 +7341,7 @@ ngx_http_qjs_ext_send(JSContext *cx, JSValueConst this_val,
 
         b = ngx_calloc_buf(r->pool);
         if (b == NULL) {
-            return JS_ThrowInternalError(cx, "failed to allocate buffer");
+            return JS_ThrowOutOfMemory(cx);
         }
 
         b->start = s.data;
@@ -7349,7 +7352,7 @@ ngx_http_qjs_ext_send(JSContext *cx, JSValueConst this_val,
 
         cl = ngx_alloc_chain_link(r->pool);
         if (cl == NULL) {
-            return JS_ThrowInternalError(cx, "failed to allocate chain link");
+            return JS_ThrowOutOfMemory(cx);
         }
 
         cl->buf = b;
@@ -7384,7 +7387,7 @@ ngx_http_qjs_ext_send_buffer(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
@@ -7527,7 +7530,7 @@ ngx_http_qjs_ext_send_header(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     if (ngx_http_set_content_type(r) != NGX_OK) {
@@ -7553,7 +7556,7 @@ ngx_http_qjs_ext_set_return_value(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
@@ -7660,7 +7663,7 @@ ngx_http_qjs_ext_subrequest(JSContext *cx, JSValueConst this_val,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     ctx = ngx_http_get_module_ctx(r, ngx_http_js_module);
@@ -7920,7 +7923,7 @@ ngx_http_qjs_ext_raw_headers(JSContext *cx, JSValueConst this_val, int out)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     headers = (out) ? &r->headers_out.headers : &r->headers_in.headers;
@@ -8003,7 +8006,7 @@ ngx_http_qjs_ext_variables(JSContext *cx, JSValueConst this_val, int type)
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     obj = JS_NewObjectProtoClass(cx, JS_NULL, NGX_QJS_CLASS_ID_HTTP_VARS);
@@ -8033,7 +8036,7 @@ ngx_http_qjs_ext_js_var_names(JSContext *cx, JSValueConst this_val, int argc,
 
     r = ngx_http_qjs_request(this_val);
     if (r == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a request object");
     }
 
     prefix = NULL;
@@ -8110,7 +8113,7 @@ ngx_http_qjs_variables_own_property(JSContext *cx, JSPropertyDescriptor *pdesc,
     r = (ngx_http_request_t *) ((uintptr_t) r & ~(uintptr_t) 1);
 
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a request object");
         return -1;
     }
 
@@ -8204,7 +8207,7 @@ ngx_http_qjs_variables_set_property(JSContext *cx, JSValueConst obj,
     r = (ngx_http_request_t *) ((uintptr_t) r & ~(uintptr_t) 1);
 
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a request object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a request object");
         return -1;
     }
 
@@ -8235,7 +8238,7 @@ ngx_http_qjs_variables_set_property(JSContext *cx, JSValueConst obj,
     JS_FreeCString(cx, (char *) name.data);
 
     if (v == NULL) {
-        (void) JS_ThrowInternalError(cx, "variable not found");
+        (void) JS_ThrowTypeError(cx, "variable not found");
         return -1;
     }
 
@@ -8339,7 +8342,7 @@ ngx_http_qjs_headers_in_own_property_names(JSContext *cx,
 
     r = JS_GetOpaque(obj, NGX_QJS_CLASS_ID_HTTP_HEADERS_IN);
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a headers_in object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a headers_in object");
         return -1;
     }
 
@@ -8547,7 +8550,7 @@ ngx_http_qjs_headers_in_own_property(JSContext *cx, JSPropertyDescriptor *pdesc,
 
     r = JS_GetOpaque(obj, NGX_QJS_CLASS_ID_HTTP_HEADERS_IN);
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a headers_in object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a headers_in object");
         return -1;
     }
 
@@ -8587,8 +8590,7 @@ ngx_http_qjs_headers_out_own_property_names(JSContext *cx,
 
     r = JS_GetOpaque(obj, NGX_QJS_CLASS_ID_HTTP_HEADERS_OUT);
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a headers_out"
-                                     " object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a headers_out object");
         return -1;
     }
 
@@ -8957,8 +8959,8 @@ ngx_http_qjs_headers_out_content_length(JSContext *cx, ngx_http_request_t *r,
             n = ngx_atoi(h->value.data, h->value.len);
             if (n == NGX_ERROR) {
                 h->hash = 0;
-                (void) JS_ThrowInternalError(cx, "failed converting argument "
-                                             "to positive integer");
+                (void) JS_ThrowTypeError(cx, "failed converting argument "
+                                         "to positive integer");
                 return -1;
             }
 
@@ -9193,8 +9195,7 @@ ngx_http_qjs_headers_out_own_property(JSContext *cx,
 
     r = JS_GetOpaque(obj, NGX_QJS_CLASS_ID_HTTP_HEADERS_OUT);
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a headers_out"
-                                     " object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a headers_out object");
         return -1;
     }
 
@@ -9233,8 +9234,7 @@ ngx_http_qjs_headers_out_define_own_property(JSContext *cx,
 
     r = JS_GetOpaque(obj, NGX_QJS_CLASS_ID_HTTP_HEADERS_OUT);
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a headers_out"
-                                     " object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a headers_out object");
         return -1;
     }
 
@@ -9273,8 +9273,7 @@ ngx_http_qjs_headers_out_delete_property(JSContext *cx,
 
     r = JS_GetOpaque(obj, NGX_QJS_CLASS_ID_HTTP_HEADERS_OUT);
     if (r == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a headers_out"
-                                     " object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a headers_out object");
         return -1;
     }
 

--- a/nginx/ngx_js.c
+++ b/nginx/ngx_js.c
@@ -1939,7 +1939,7 @@ ngx_qjs_ext_console_time(JSContext *cx, JSValueConst this_val, int argc,
 
     console = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_CONSOLE);
     if (console == NULL) {
-        return JS_ThrowInternalError(cx, "this is not a console object");
+        return JS_ThrowTypeError(cx, "this is not a console object");
     }
 
     if (console == (void *) 1) {
@@ -2026,7 +2026,7 @@ ngx_qjs_ext_console_time_end(JSContext *cx, JSValueConst this_val, int argc,
 
     console = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_CONSOLE);
     if (console == NULL) {
-        return JS_ThrowInternalError(cx, "this is not a console object");
+        return JS_ThrowTypeError(cx, "this is not a console object");
     }
 
     if (!JS_IsUndefined(argv[0])) {

--- a/nginx/ngx_js.c
+++ b/nginx/ngx_js.c
@@ -1896,7 +1896,7 @@ ngx_qjs_ext_log(JSContext *cx, JSValueConst this_val, int argc,
 
     p = JS_GetContextOpaque(cx);
     if (p == NULL) {
-        return JS_ThrowInternalError(cx, "external is not set");
+        return JS_ThrowTypeError(cx, "external is not set");
     }
 
     level = magic & NGX_JS_LOG_MASK;
@@ -2466,7 +2466,7 @@ ngx_js_integer(njs_vm_t *vm, njs_value_t *value, ngx_int_t *n)
     double  num;
 
     if (!njs_value_is_valid_number(value)) {
-        njs_vm_error(vm, "is not a number");
+        njs_vm_type_error(vm, "invalid number");
         return NGX_ERROR;
     }
 
@@ -2828,7 +2828,7 @@ ngx_js_ext_log(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     p = njs_vm_external(vm, NJS_PROTO_ID_ANY, njs_argument(args, 0));
     if (p == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "external is not set");
         return NJS_ERROR;
     }
 

--- a/nginx/ngx_js_fetch.c
+++ b/nginx/ngx_js_fetch.c
@@ -540,7 +540,7 @@ ngx_js_ext_fetch(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (u.host.len >= NGX_JS_HOST_MAX_LEN) {
-        njs_vm_error(vm, "Host name too long");
+        njs_vm_type_error(vm, "Host name too long");
         goto fail;
     }
 
@@ -608,7 +608,7 @@ ngx_js_ext_fetch(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
                                            &http->proxy.url, &http->proxy.auth)
                 != NGX_OK)
             {
-                njs_vm_error(vm, "failed to evaluate proxy URL");
+                njs_vm_internal_error(vm, "failed to evaluate proxy URL");
                 goto fail;
             }
 
@@ -628,7 +628,7 @@ ngx_js_ext_fetch(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (ngx_js_check_request_line_component(u.uri.data, u.uri.len) != NGX_OK) {
-        njs_vm_error(vm, "invalid url");
+        njs_vm_type_error(vm, "invalid url");
         goto fail;
     }
 
@@ -649,7 +649,7 @@ ngx_js_ext_fetch(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         }
 
         if (ctx == NGX_NO_RESOLVER) {
-            njs_vm_error(vm, "no resolver defined");
+            njs_vm_internal_error(vm, "no resolver defined");
             goto fail;
         }
 
@@ -801,13 +801,12 @@ ngx_js_ext_response_constructor(njs_vm_t *vm, njs_value_t *args,
         value = njs_vm_object_prop(vm, init, &status, &lvalue);
         if (value != NULL) {
             if (ngx_js_integer(vm, value, &response->code) != NGX_OK) {
-                njs_vm_error(vm, "invalid Response status");
                 return NJS_ERROR;
             }
 
             if (response->code < 200 || response->code > 599) {
-                njs_vm_error(vm, "status provided (%i) is outside of "
-                             "[200, 599] range", response->code);
+                njs_vm_range_error(vm, "status provided (%i) is outside of "
+                                   "[200, 599] range", response->code);
                 return NJS_ERROR;
             }
         }
@@ -815,7 +814,6 @@ ngx_js_ext_response_constructor(njs_vm_t *vm, njs_value_t *args,
         value = njs_vm_object_prop(vm, init, &status_text, &lvalue);
         if (value != NULL) {
             if (ngx_js_ngx_string(vm, value, &response->status_text) != NGX_OK) {
-                njs_vm_error(vm, "invalid Response statusText");
                 return NJS_ERROR;
             }
 
@@ -824,7 +822,7 @@ ngx_js_ext_response_constructor(njs_vm_t *vm, njs_value_t *args,
 
             while (p < end) {
                 if (*p != '\t' && *p < ' ') {
-                    njs_vm_error(vm, "invalid Response statusText");
+                    njs_vm_type_error(vm, "invalid Response statusText");
                     return NJS_ERROR;
                 }
 
@@ -835,7 +833,7 @@ ngx_js_ext_response_constructor(njs_vm_t *vm, njs_value_t *args,
         value = njs_vm_object_prop(vm, init, &headers, &lvalue);
         if (value != NULL) {
             if (!njs_value_is_object(value)) {
-                njs_vm_error(vm, "Headers is not an object");
+                njs_vm_type_error(vm, "Headers is not an object");
                 return NJS_ERROR;
             }
 
@@ -852,7 +850,6 @@ ngx_js_ext_response_constructor(njs_vm_t *vm, njs_value_t *args,
 
     if (!njs_value_is_null_or_undefined(body)) {
         if (ngx_js_string(vm, body, &bd) != NGX_OK) {
-            njs_vm_error(vm, "invalid Response body");
             return NJS_ERROR;
         }
 
@@ -908,13 +905,13 @@ ngx_js_method_process(njs_vm_t *vm, ngx_js_request_t *request)
                                                request->method.len)
            != NGX_OK)
     {
-        njs_vm_error(vm, "invalid Request method");
+        njs_vm_type_error(vm, "invalid Request method");
         return NJS_ERROR;
     }
 
     for (m = &forbidden[0]; m->length != 0; m++) {
         if (njs_strstr_case_eq(&str, m)) {
-            njs_vm_error(vm, "forbidden method: %V", m);
+            njs_vm_type_error(vm, "forbidden method: %V", m);
             return NJS_ERROR;
         }
     }
@@ -1012,7 +1009,8 @@ ngx_js_headers_fill(njs_vm_t *vm, ngx_js_headers_t *headers, njs_value_t *init)
             start++;
 
             if (len != 2) {
-                njs_vm_error(vm, "header does not contain exactly two items");
+                njs_vm_type_error(vm,
+                                  "header does not contain exactly two items");
                 return NJS_ERROR;
             }
 
@@ -1143,7 +1141,7 @@ ngx_js_fetch_alloc(njs_vm_t *vm, ngx_pool_t *pool, ngx_log_t *log,
 
 failed:
 
-    njs_vm_error(vm, "internal error");
+    njs_vm_internal_error(vm, "internal error");
 
     return NULL;
 }
@@ -1220,7 +1218,7 @@ ngx_js_fetch_promissified_result(njs_vm_t *vm, njs_value_t *result,
 
 error:
 
-    njs_vm_error(vm, "internal error");
+    njs_vm_internal_error(vm, "internal error");
 
     return NJS_ERROR;
 }
@@ -1299,7 +1297,7 @@ ngx_js_request_constructor(njs_vm_t *vm, ngx_js_request_t *request,
 
     input = njs_arg(args, nargs, 1);
     if (njs_value_is_undefined(input)) {
-        njs_vm_error(vm, "1st argument is required");
+        njs_vm_type_error(vm, "1st argument is required");
         return NJS_ERROR;
     }
 
@@ -1334,14 +1332,13 @@ ngx_js_request_constructor(njs_vm_t *vm, ngx_js_request_t *request,
     if (njs_value_is_string(input)) {
         ret = ngx_js_ngx_string(vm, input, &request->url);
         if (ret != NJS_OK) {
-            njs_vm_error(vm, "failed to convert url arg");
             return NJS_ERROR;
         }
 
     } else {
         orig = njs_vm_external(vm, ngx_http_js_fetch_request_proto_id, input);
         if (orig == NULL) {
-            njs_vm_error(vm, "input is not string or a Request object");
+            njs_vm_type_error(vm, "input is not string or a Request object");
             return NJS_ERROR;
         }
 
@@ -1385,13 +1382,13 @@ ngx_js_request_constructor(njs_vm_t *vm, ngx_js_request_t *request,
 #endif
 
     } else {
-        njs_vm_error(vm, "unsupported URL schema (only http or https are"
-                     " supported)");
+        njs_vm_type_error(vm, "unsupported URL schema (only http or https are"
+                          " supported)");
         return NJS_ERROR;
     }
 
     if (ngx_parse_url(pool, u) != NGX_OK) {
-        njs_vm_error(vm, "invalid url");
+        njs_vm_type_error(vm, "invalid url");
         return NJS_ERROR;
     }
 
@@ -1402,7 +1399,6 @@ ngx_js_request_constructor(njs_vm_t *vm, ngx_js_request_t *request,
         if (value != NULL && ngx_js_ngx_string(vm, value, &request->method)
             != NGX_OK)
         {
-            njs_vm_error(vm, "invalid Request method");
             return NJS_ERROR;
         }
 
@@ -1446,7 +1442,7 @@ ngx_js_request_constructor(njs_vm_t *vm, ngx_js_request_t *request,
         headers = njs_vm_object_prop(vm, init, &headers_key, &lvalue);
         if (headers != NULL) {
             if (!njs_value_is_object(headers)) {
-                njs_vm_error(vm, "Headers is not an object");
+                njs_vm_type_error(vm, "Headers is not an object");
                 return NJS_ERROR;
             }
 
@@ -1474,7 +1470,6 @@ ngx_js_request_constructor(njs_vm_t *vm, ngx_js_request_t *request,
         value = njs_vm_object_prop(vm, init, &body_key, &lvalue);
         if (value != NULL) {
             if (ngx_js_ngx_string(vm, value, &request->body) != NGX_OK) {
-                njs_vm_error(vm, "invalid Request body");
                 return NJS_ERROR;
             }
 
@@ -1543,18 +1538,18 @@ ngx_js_headers_append(njs_vm_t *vm, ngx_js_headers_t *headers,
 
     ret = ngx_js_check_header_name(name, len);
     if (ret != NGX_OK) {
-        njs_vm_error(vm, "invalid header name");
+        njs_vm_type_error(vm, "invalid header name");
         return NJS_ERROR;
     }
 
     ret = ngx_js_check_header_value(value, vlen);
     if (ret != NGX_OK) {
-        njs_vm_error(vm, "invalid header value");
+        njs_vm_type_error(vm, "invalid header value");
         return NJS_ERROR;
     }
 
     if (headers->guard == GUARD_IMMUTABLE) {
-        njs_vm_error(vm, "cannot append to immutable object");
+        njs_vm_type_error(vm, "cannot append to immutable object");
         return NJS_ERROR;
     }
 
@@ -1724,7 +1719,7 @@ ngx_headers_js_ext_append(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     headers = njs_vm_external(vm, ngx_http_js_fetch_headers_proto_id,
                               njs_argument(args, 0));
     if (headers == NULL) {
-        njs_vm_error(vm, "\"this\" is not fetch headers object");
+        njs_vm_type_error(vm, "\"this\" is not fetch headers object");
         return NJS_ERROR;
     }
 
@@ -1764,7 +1759,7 @@ ngx_headers_js_ext_delete(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     headers = njs_vm_external(vm, ngx_http_js_fetch_headers_proto_id,
                               njs_argument(args, 0));
     if (headers == NULL) {
-        njs_vm_error(vm, "\"this\" is not fetch headers object");
+        njs_vm_type_error(vm, "\"this\" is not fetch headers object");
         return NJS_ERROR;
     }
 
@@ -1827,14 +1822,14 @@ ngx_headers_js_ext_for_each(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     headers = njs_vm_external(vm, ngx_http_js_fetch_headers_proto_id, this);
     if (headers == NULL) {
-        njs_vm_error(vm, "\"this\" is not fetch headers object");
+        njs_vm_type_error(vm, "\"this\" is not fetch headers object");
         return NJS_ERROR;
     }
 
     callback = njs_arg(args, nargs, 1);
 
     if (!njs_value_is_function(callback)) {
-        njs_vm_error(vm, "\"callback\" is not a function");
+        njs_vm_type_error(vm, "\"callback\" is not a function");
         return NJS_ERROR;
     }
 
@@ -2064,7 +2059,7 @@ ngx_headers_js_ext_set(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     headers = njs_vm_external(vm, ngx_http_js_fetch_headers_proto_id,
                               njs_argument(args, 0));
     if (headers == NULL) {
-        njs_vm_error(vm, "\"this\" is not fetch headers object");
+        njs_vm_type_error(vm, "\"this\" is not fetch headers object");
         return NJS_ERROR;
     }
 
@@ -2145,7 +2140,7 @@ ngx_request_js_ext_body(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (request->body_used) {
-        njs_vm_error(vm, "body stream already read");
+        njs_vm_type_error(vm, "body stream already read");
         return NJS_ERROR;
     }
 
@@ -2258,7 +2253,7 @@ ngx_request_js_ext_headers(njs_vm_t *vm, njs_object_prop_t *prop,
                                      ngx_http_js_fetch_headers_proto_id,
                                      &request->headers, 0);
         if (ret != NJS_OK) {
-            njs_vm_error(vm, "fetch header creation failed");
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
     }
@@ -2303,7 +2298,7 @@ ngx_response_js_ext_body(njs_vm_t *vm, njs_value_t *args,
     }
 
     if (response->body_used) {
-        njs_vm_error(vm, "body stream already read");
+        njs_vm_type_error(vm, "body stream already read");
         return NJS_ERROR;
     }
 
@@ -2385,7 +2380,7 @@ ngx_response_js_ext_headers(njs_vm_t *vm, njs_object_prop_t *prop,
                                      ngx_http_js_fetch_headers_proto_id,
                                      &response->headers, 0);
         if (ret != NJS_OK) {
-            njs_vm_error(vm, "fetch header creation failed");
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
     }
@@ -2509,7 +2504,7 @@ ngx_fetch_flag_set(njs_vm_t *vm, const ngx_js_entry_t *entries,
         }
     }
 
-    njs_vm_error(vm, "unknown %s type: %V", type, &flag);
+    njs_vm_type_error(vm, "unknown %s type: %V", type, &flag);
 
     return NJS_ERROR;
 }

--- a/nginx/ngx_qjs_fetch.c
+++ b/nginx/ngx_qjs_fetch.c
@@ -558,12 +558,15 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
     if (JS_IsString(input)) {
         rc = ngx_qjs_string(cx, pool, input, &request->url);
         if (rc != NGX_OK) {
-            JS_ThrowInternalError(cx, "failed to convert url arg");
+            if (!JS_HasException(cx)) {
+                JS_ThrowOutOfMemory(cx);
+            }
+
             return NGX_ERROR;
         }
 
     } else {
-        orig = JS_GetOpaque2(cx, input, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+        orig = JS_GetOpaque(input, NGX_QJS_CLASS_ID_FETCH_REQUEST);
         if (orig == NULL) {
             JS_ThrowInternalError(cx,
                                   "input is not string or a Request object");
@@ -632,7 +635,10 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
             JS_FreeValue(cx, value);
 
             if (rc != NGX_OK) {
-                JS_ThrowInternalError(cx, "invalid Request method");
+                if (!JS_HasException(cx)) {
+                    JS_ThrowOutOfMemory(cx);
+                }
+
                 return NGX_ERROR;
             }
         }
@@ -673,6 +679,7 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
 
         if (!JS_IsUndefined(value)) {
             if (!JS_IsObject(value)) {
+                JS_FreeValue(cx, value);
                 JS_ThrowInternalError(cx, "Headers is not an object");
                 return NGX_ERROR;
             }
@@ -710,7 +717,10 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
         if (!JS_IsUndefined(value)) {
             if (ngx_qjs_string(cx, pool, value, &request->body) != NGX_OK) {
                 JS_FreeValue(cx, value);
-                JS_ThrowInternalError(cx, "invalid Request body");
+                if (!JS_HasException(cx)) {
+                    JS_ThrowOutOfMemory(cx);
+                }
+
                 return NGX_ERROR;
             }
 
@@ -806,6 +816,10 @@ ngx_qjs_fetch_response_ctor(JSContext *cx, JSValueConst new_target, int argc,
             JS_FreeValue(cx, value);
 
             if (ret < 0) {
+                if (!JS_HasException(cx)) {
+                    JS_ThrowOutOfMemory(cx);
+                }
+
                 return JS_EXCEPTION;
             }
 
@@ -1033,12 +1047,20 @@ ngx_qjs_headers_fill_header_free(JSContext *cx, ngx_js_headers_t *headers,
     pool = ngx_qjs_external_pool(cx, JS_GetContextOpaque(cx));
 
     if (ngx_qjs_string(cx, pool, prop_name, &name) != NGX_OK) {
+        if (!JS_HasException(cx)) {
+            JS_ThrowOutOfMemory(cx);
+        }
+
         JS_FreeValue(cx, prop_name);
         JS_FreeValue(cx, prop_value);
         return NGX_ERROR;
     }
 
     if (ngx_qjs_string(cx, pool, prop_value, &value) != NGX_OK) {
+        if (!JS_HasException(cx)) {
+            JS_ThrowOutOfMemory(cx);
+        }
+
         JS_FreeValue(cx, prop_name);
         JS_FreeValue(cx, prop_value);
         return NGX_ERROR;
@@ -1063,7 +1085,7 @@ ngx_qjs_headers_fill(JSContext *cx, ngx_js_headers_t *headers, JSValue init)
     JSPropertyEnum    *tab;
     ngx_js_headers_t  *hh;
 
-    hh = JS_GetOpaque2(cx, init, NGX_QJS_CLASS_ID_FETCH_HEADERS);
+    hh = JS_GetOpaque(init, NGX_QJS_CLASS_ID_FETCH_HEADERS);
     if (hh != NULL) {
         return ngx_qjs_headers_inherit(cx, headers, hh);
     }

--- a/nginx/ngx_qjs_fetch.c
+++ b/nginx/ngx_qjs_fetch.c
@@ -260,7 +260,7 @@ ngx_qjs_ext_fetch(JSContext *cx, JSValueConst this_val, int argc,
     }
 
     if (u.host.len >= NGX_JS_HOST_MAX_LEN) {
-        JS_ThrowInternalError(cx, "Host name too long");
+        JS_ThrowTypeError(cx, "Host name too long");
         goto fail;
     }
 
@@ -365,7 +365,7 @@ ngx_qjs_ext_fetch(JSContext *cx, JSValueConst this_val, int argc,
     }
 
     if (ngx_js_check_request_line_component(u.uri.data, u.uri.len) != NGX_OK) {
-        JS_ThrowInternalError(cx, "invalid url");
+        JS_ThrowTypeError(cx, "invalid url");
         goto fail;
     }
 
@@ -522,7 +522,7 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
 
     input = argv[0];
     if (JS_IsUndefined(input)) {
-        JS_ThrowInternalError(cx, "1st argument is required");
+        JS_ThrowTypeError(cx, "1st argument is required");
         return NGX_ERROR;
     }
 
@@ -568,8 +568,8 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
     } else {
         orig = JS_GetOpaque(input, NGX_QJS_CLASS_ID_FETCH_REQUEST);
         if (orig == NULL) {
-            JS_ThrowInternalError(cx,
-                                  "input is not string or a Request object");
+            JS_ThrowTypeError(cx,
+                              "input is not string or a Request object");
             return NGX_ERROR;
         }
 
@@ -612,13 +612,13 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
 #endif
 
     } else {
-        JS_ThrowInternalError(cx, "unsupported URL schema (only http or https"
-                                  " are supported)");
+        JS_ThrowTypeError(cx, "unsupported URL schema (only http or https"
+                              " are supported)");
         return NGX_ERROR;
     }
 
     if (ngx_parse_url(pool, u) != NGX_OK) {
-        JS_ThrowInternalError(cx, "invalid url");
+        JS_ThrowTypeError(cx, "invalid url");
         return NGX_ERROR;
     }
 
@@ -626,7 +626,6 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
         init = argv[1];
         value = JS_GetPropertyStr(cx, init, "method");
         if (JS_IsException(value)) {
-            JS_ThrowInternalError(cx, "invalid Request method");
             return NGX_ERROR;
         }
 
@@ -673,14 +672,13 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
 
         value = JS_GetPropertyStr(cx, init, "headers");
         if (JS_IsException(value)) {
-            JS_ThrowInternalError(cx, "invalid Request headers");
             return NGX_ERROR;
         }
 
         if (!JS_IsUndefined(value)) {
             if (!JS_IsObject(value)) {
                 JS_FreeValue(cx, value);
-                JS_ThrowInternalError(cx, "Headers is not an object");
+                JS_ThrowTypeError(cx, "Headers is not an object");
                 return NGX_ERROR;
             }
 
@@ -710,7 +708,6 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
 
         value = JS_GetPropertyStr(cx, init, "body");
         if (JS_IsException(value)) {
-            JS_ThrowInternalError(cx, "invalid Request body");
             return NGX_ERROR;
         }
 
@@ -788,7 +785,7 @@ ngx_qjs_fetch_response_ctor(JSContext *cx, JSValueConst new_target, int argc,
     if (JS_IsObject(init)) {
         value = JS_GetPropertyStr(cx, init, "status");
         if (JS_IsException(value)) {
-            return JS_ThrowInternalError(cx, "invalid Response status");
+            return JS_EXCEPTION;
         }
 
         if (!JS_IsUndefined(value)) {
@@ -800,15 +797,15 @@ ngx_qjs_fetch_response_ctor(JSContext *cx, JSValueConst new_target, int argc,
             }
 
             if (response->code < 200 || response->code > 599) {
-                return JS_ThrowInternalError(cx, "status provided (%d) is "
-                                                 "outside of [200, 599] range",
-                                             (int) response->code);
+                return JS_ThrowRangeError(cx, "status provided (%d) is "
+                                              "outside of [200, 599] range",
+                                          (int) response->code);
             }
         }
 
         value = JS_GetPropertyStr(cx, init, "statusText");
         if (JS_IsException(value)) {
-            return JS_ThrowInternalError(cx, "invalid Response statusText");
+            return JS_EXCEPTION;
         }
 
         if (!JS_IsUndefined(value)) {
@@ -828,8 +825,8 @@ ngx_qjs_fetch_response_ctor(JSContext *cx, JSValueConst new_target, int argc,
 
             while (p < end) {
                 if (*p != '\t' && *p < ' ') {
-                    return JS_ThrowInternalError(cx,
-                                                 "invalid Response statusText");
+                    return JS_ThrowTypeError(cx,
+                                             "invalid Response statusText");
                 }
 
                 p++;
@@ -838,13 +835,13 @@ ngx_qjs_fetch_response_ctor(JSContext *cx, JSValueConst new_target, int argc,
 
         value = JS_GetPropertyStr(cx, init, "headers");
         if (JS_IsException(value)) {
-            return JS_ThrowInternalError(cx, "invalid Response headers");
+            return JS_EXCEPTION;
         }
 
         if (!JS_IsUndefined(value)) {
             if (!JS_IsObject(value)) {
                 JS_FreeValue(cx, value);
-                return JS_ThrowInternalError(cx, "Headers is not an object");
+                return JS_ThrowTypeError(cx, "Headers is not an object");
             }
 
             rc = ngx_qjs_headers_fill(cx, &response->headers, value);
@@ -962,7 +959,7 @@ ngx_qjs_method_process(JSContext *cx, ngx_js_request_t *request)
                                                request->method.len)
            != NGX_OK)
     {
-        JS_ThrowInternalError(cx, "invalid Request method");
+        JS_ThrowTypeError(cx, "invalid Request method");
         return NGX_ERROR;
     }
 
@@ -970,8 +967,8 @@ ngx_qjs_method_process(JSContext *cx, ngx_js_request_t *request)
         if (request->method.len == m->len
             && ngx_strncasecmp(request->method.data, m->data, m->len) == 0)
         {
-            JS_ThrowInternalError(cx, "forbidden method: %.*s",
-                                  (int) m->len, m->data);
+            JS_ThrowTypeError(cx, "forbidden method: %.*s",
+                              (int) m->len, m->data);
             return NGX_ERROR;
         }
     }
@@ -1109,8 +1106,8 @@ ngx_qjs_headers_fill(JSContext *cx, ngx_js_headers_t *headers, JSValue init)
 
             if (length != 2) {
                 JS_FreeValue(cx, header);
-                JS_ThrowInternalError(cx,
-                                   "header does not contain exactly two items");
+                JS_ThrowTypeError(cx,
+                                  "header does not contain exactly two items");
                 goto fail;
             }
 
@@ -1368,18 +1365,18 @@ ngx_qjs_headers_append(JSContext *cx, ngx_js_headers_t *headers,
 
     ret = ngx_js_check_header_name(name, len);
     if (ret != NGX_OK) {
-        JS_ThrowInternalError(cx, "invalid header name");
+        JS_ThrowTypeError(cx, "invalid header name");
         return NGX_ERROR;
     }
 
     ret = ngx_js_check_header_value(value, vlen);
     if (ret != NGX_OK) {
-        JS_ThrowInternalError(cx, "invalid header value");
+        JS_ThrowTypeError(cx, "invalid header value");
         return NGX_ERROR;
     }
 
     if (headers->guard == GUARD_IMMUTABLE) {
-        JS_ThrowInternalError(cx, "cannot append to immutable object");
+        JS_ThrowTypeError(cx, "cannot append to immutable object");
         return NGX_ERROR;
     }
 
@@ -1699,9 +1696,9 @@ ngx_qjs_fetch_headers_own_property_names(JSContext *cx, JSPropertyEnum **ptab,
     ngx_js_tb_elt_t   *h;
     ngx_js_headers_t  *headers;
 
-    headers = JS_GetOpaque2(cx, obj, NGX_QJS_CLASS_ID_FETCH_HEADERS);
+    headers = JS_GetOpaque(obj, NGX_QJS_CLASS_ID_FETCH_HEADERS);
     if (headers == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a Headers object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a Headers object");
         return -1;
     }
 
@@ -1766,10 +1763,10 @@ ngx_qjs_ext_fetch_headers_append(JSContext *cx, JSValueConst this_val,
     ngx_int_t          rc;
     ngx_js_headers_t  *headers;
 
-    headers = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
+    headers = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
     if (headers == NULL) {
-        return JS_ThrowInternalError(cx,
-                                     "\"this\" is not fetch headers object");
+        return JS_ThrowTypeError(cx,
+                                 "\"this\" is not fetch headers object");
     }
 
     rc = ngx_qjs_headers_fill_header_free(cx, headers,
@@ -1793,10 +1790,10 @@ ngx_qjs_ext_fetch_headers_delete(JSContext *cx, JSValueConst this_val,
     ngx_js_tb_elt_t   *h;
     ngx_js_headers_t  *headers;
 
-    headers = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
+    headers = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
     if (headers == NULL) {
-        return JS_ThrowInternalError(cx,
-                                     "\"this\" is not fetch headers object");
+        return JS_ThrowTypeError(cx,
+                                 "\"this\" is not fetch headers object");
     }
 
     name.data = (u_char *) JS_ToCStringLen(cx, &name.len, argv[0]);
@@ -1854,16 +1851,16 @@ ngx_qjs_ext_fetch_headers_foreach(JSContext *cx, JSValueConst this_val,
     ngx_uint_t         i;
     ngx_js_headers_t  *headers;
 
-    headers = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
+    headers = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
     if (headers == NULL) {
-        return JS_ThrowInternalError(cx,
-                                     "\"this\" is not fetch headers object");
+        return JS_ThrowTypeError(cx,
+                                 "\"this\" is not fetch headers object");
     }
 
     callback = argv[0];
 
     if (!JS_IsFunction(cx, callback)) {
-        return JS_ThrowInternalError(cx, "\"callback\" is not a function");
+        return JS_ThrowTypeError(cx, "\"callback\" is not a function");
     }
 
     keys = ngx_qjs_headers_ext_keys(cx, this_val);
@@ -1974,10 +1971,10 @@ ngx_qjs_ext_fetch_headers_set(JSContext *cx, JSValueConst this_val,
     ngx_js_tb_elt_t   *h, **ph, **pp;
     ngx_js_headers_t  *headers;
 
-    headers = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
+    headers = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_FETCH_HEADERS);
     if (headers == NULL) {
-        return JS_ThrowInternalError(cx,
-                                     "\"this\" is not fetch headers object");
+        return JS_ThrowTypeError(cx,
+                                 "\"this\" is not fetch headers object");
     }
 
     name.data = (u_char *) JS_ToCStringLen(cx, &name.len, argv[0]);
@@ -2057,7 +2054,7 @@ ngx_qjs_ext_fetch_request_body(JSContext *cx, JSValueConst this_val,
     }
 
     if (request->body_used) {
-        return JS_ThrowInternalError(cx, "body stream already read");
+        return JS_ThrowTypeError(cx, "body stream already read");
     }
 
     request->body_used = 1;
@@ -2171,7 +2168,7 @@ ngx_qjs_ext_fetch_request_headers(JSContext *cx, JSValueConst this_val)
     if (JS_IsUndefined(header)) {
         header = JS_NewObjectClass(cx, NGX_QJS_CLASS_ID_FETCH_HEADERS);
         if (JS_IsException(header)) {
-            return JS_ThrowInternalError(cx, "fetch header creation failed");
+            return JS_ThrowOutOfMemory(cx);
         }
 
         JS_SetOpaque(header, &request->headers);
@@ -2298,7 +2295,7 @@ ngx_qjs_ext_fetch_response_headers(JSContext *cx, JSValueConst this_val)
     if (JS_IsUndefined(header)) {
         header = JS_NewObjectClass(cx, NGX_QJS_CLASS_ID_FETCH_HEADERS);
         if (JS_IsException(header)) {
-            return JS_ThrowInternalError(cx, "fetch header creation failed");
+            return JS_ThrowOutOfMemory(cx);
         }
 
         JS_SetOpaque(header, &response->headers);
@@ -2339,7 +2336,7 @@ ngx_qjs_ext_fetch_response_body(JSContext *cx, JSValueConst this_val,
     }
 
     if (response->body_used) {
-        return JS_ThrowInternalError(cx, "body stream already read");
+        return JS_ThrowTypeError(cx, "body stream already read");
     }
 
     response->body_used = 1;
@@ -2463,7 +2460,6 @@ ngx_qjs_fetch_flag_set(JSContext *cx, const ngx_qjs_entry_t *entries,
 
     value = JS_GetPropertyStr(cx, object, prop);
     if (JS_IsException(value)) {
-        JS_ThrowInternalError(cx, "failed to get %s property", prop);
         return NGX_ERROR;
     }
 
@@ -2486,8 +2482,8 @@ ngx_qjs_fetch_flag_set(JSContext *cx, const ngx_qjs_entry_t *entries,
         }
     }
 
-    JS_ThrowInternalError(cx, "unknown %s type: %.*s", prop,
-                          (int) flag.len, flag.data);
+    JS_ThrowTypeError(cx, "unknown %s type: %.*s", prop,
+                      (int) flag.len, flag.data);
 
     JS_FreeCString(cx, (const char *) flag.data);
 

--- a/nginx/ngx_stream_js_module.c
+++ b/nginx/ngx_stream_js_module.c
@@ -1951,6 +1951,8 @@ ngx_stream_js_session_variables(njs_vm_t *vm, njs_object_prop_t *prop,
 
     vv->data = ngx_pnalloc(s->connection->pool, val.length);
     if (vv->data == NULL) {
+        vv->valid = 0;
+        njs_vm_memory_error(vm);
         return NJS_ERROR;
     }
 

--- a/nginx/ngx_stream_js_module.c
+++ b/nginx/ngx_stream_js_module.c
@@ -1446,7 +1446,8 @@ ngx_stream_js_event(ngx_stream_session_t *s, njs_str_t *event)
     }
 
     if (i == n) {
-        njs_vm_error(ctx->engine->u.njs.vm, "unknown event \"%V\"", event);
+        njs_vm_type_error(ctx->engine->u.njs.vm, "unknown event \"%V\"",
+                          event);
         return NULL;
     }
 
@@ -1455,8 +1456,8 @@ ngx_stream_js_event(ngx_stream_session_t *s, njs_str_t *event)
     for (n = 0; n < NGX_JS_EVENT_MAX; n++) {
         type = ctx->events[n].data_type;
         if (type != NGX_JS_UNSET && type != events[i].data_type) {
-            njs_vm_error(ctx->engine->u.njs.vm, "mixing string and buffer"
-                         " events is not allowed");
+            njs_vm_type_error(ctx->engine->u.njs.vm, "mixing string and buffer"
+                              " events is not allowed");
             return NULL;
         }
     }
@@ -1498,7 +1499,7 @@ ngx_stream_js_ext_done(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     s = njs_vm_external(vm, ngx_stream_js_session_proto_id,
                         njs_argument(args, 0));
     if (s == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -1517,7 +1518,7 @@ ngx_stream_js_ext_done(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         }
 
         if (status < NGX_ABORT || status > NGX_STREAM_SERVICE_UNAVAILABLE) {
-            njs_vm_error(vm, "code is out of range");
+            njs_vm_range_error(vm, "code is out of range");
             return NJS_ERROR;
         }
     }
@@ -1526,7 +1527,7 @@ ngx_stream_js_ext_done(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_js_module);
 
     if (ctx->filter) {
-        njs_vm_error(vm, "should not be called while filtering");
+        njs_vm_type_error(vm, "should not be called while filtering");
         return NJS_ERROR;
     }
 
@@ -1555,18 +1556,18 @@ ngx_stream_js_ext_on(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     s = njs_vm_external(vm, ngx_stream_js_session_proto_id,
                         njs_argument(args, 0));
     if (s == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
     if (ngx_js_string(vm, njs_arg(args, nargs, 1), &name) == NJS_ERROR) {
-        njs_vm_error(vm, "failed to convert event arg");
+        njs_vm_type_error(vm, "failed to convert event arg");
         return NJS_ERROR;
     }
 
     callback = njs_arg(args, nargs, 2);
     if (!njs_value_is_function(callback)) {
-        njs_vm_error(vm, "callback is not a function");
+        njs_vm_type_error(vm, "callback is not a function");
         return NJS_ERROR;
     }
 
@@ -1576,7 +1577,7 @@ ngx_stream_js_ext_on(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     }
 
     if (njs_value_is_function(njs_value_arg(&event->function))) {
-        njs_vm_error(vm, "event handler \"%V\" is already set", &name);
+        njs_vm_type_error(vm, "event handler \"%V\" is already set", &name);
         return NJS_ERROR;
     }
 
@@ -1599,12 +1600,12 @@ ngx_stream_js_ext_off(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     s = njs_vm_external(vm, ngx_stream_js_session_proto_id,
                         njs_argument(args, 0));
     if (s == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
     if (ngx_js_string(vm, njs_arg(args, nargs, 1), &name) == NJS_ERROR) {
-        njs_vm_error(vm, "failed to convert event arg");
+        njs_vm_type_error(vm, "failed to convert event arg");
         return NJS_ERROR;
     }
 
@@ -1643,7 +1644,7 @@ ngx_stream_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     s = njs_vm_external(vm, ngx_stream_js_session_proto_id,
                         njs_argument(args, 0));
     if (s == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -1652,12 +1653,12 @@ ngx_stream_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_js_module);
 
     if (!ctx->filter) {
-        njs_vm_error(vm, "cannot send buffer in this handler");
+        njs_vm_type_error(vm, "cannot send buffer in this handler");
         return NJS_ERROR;
     }
 
     if (ngx_js_string(vm, njs_arg(args, nargs, 1), &buffer) != NGX_OK) {
-        njs_vm_error(vm, "failed to get buffer arg");
+        njs_vm_type_error(vm, "failed to get buffer arg");
         return NJS_ERROR;
     }
 
@@ -1702,7 +1703,7 @@ ngx_stream_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     cl = ngx_chain_get_free_buf(c->pool, &ctx->free);
     if (cl == NULL) {
-        njs_vm_error(vm, "memory error");
+        njs_vm_memory_error(vm);
         return NJS_ERROR;
     }
 
@@ -1727,7 +1728,7 @@ ngx_stream_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     } else {
 
         if (ngx_stream_js_next_filter(s, ctx, cl, from_upstream) == NGX_ERROR) {
-            njs_vm_error(vm, "ngx_stream_js_next_filter() failed");
+            njs_vm_internal_error(vm, "ngx_stream_js_next_filter() failed");
             return NJS_ERROR;
         }
     }
@@ -1738,8 +1739,8 @@ ngx_stream_js_ext_send(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
 exception:
 
-    njs_vm_error(vm, "\"from_upstream\" flag is expected when"
-                "called asynchronously");
+    njs_vm_type_error(vm, "\"from_upstream\" flag is expected when "
+                      "called asynchronously");
 
     return NJS_ERROR;
 }
@@ -1755,7 +1756,7 @@ ngx_stream_js_ext_set_return_value(njs_vm_t *vm, njs_value_t *args,
     s = njs_vm_external(vm, ngx_stream_js_session_proto_id,
                         njs_argument(args, 0));
     if (s == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -1796,7 +1797,7 @@ ngx_stream_js_ext_js_var_names(njs_vm_t *vm, njs_value_t *args,
     s = njs_vm_external(vm, ngx_stream_js_session_proto_id,
                         njs_argument(args, 0));
     if (s == NULL) {
-        njs_vm_error(vm, "\"this\" is not an external");
+        njs_vm_type_error(vm, "\"this\" is not an external");
         return NJS_ERROR;
     }
 
@@ -1877,7 +1878,7 @@ ngx_stream_js_session_variables(njs_vm_t *vm, njs_object_prop_t *prop,
         } else {
             name.data = ngx_pnalloc(s->connection->pool, val.length);
             if (name.data == NULL) {
-                njs_vm_error(vm, "internal error");
+                njs_vm_memory_error(vm);
                 return NJS_ERROR;
             }
         }
@@ -1904,7 +1905,7 @@ ngx_stream_js_session_variables(njs_vm_t *vm, njs_object_prop_t *prop,
     } else {
         name.data = ngx_pnalloc(s->connection->pool, val.length);
         if (name.data == NULL) {
-            njs_vm_error(vm, "internal error");
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
     }
@@ -1914,7 +1915,7 @@ ngx_stream_js_session_variables(njs_vm_t *vm, njs_object_prop_t *prop,
     v = ngx_hash_find(&cmcf->variables_hash, key, name.data, val.length);
 
     if (v == NULL) {
-        njs_vm_error(vm, "variable not found");
+        njs_vm_type_error(vm, "variable not found");
         return NJS_ERROR;
     }
 
@@ -1926,6 +1927,7 @@ ngx_stream_js_session_variables(njs_vm_t *vm, njs_object_prop_t *prop,
         vv = ngx_pcalloc(s->connection->pool,
                          sizeof(ngx_stream_variable_value_t));
         if (vv == NULL) {
+            njs_vm_memory_error(vm);
             return NJS_ERROR;
         }
 
@@ -1940,7 +1942,7 @@ ngx_stream_js_session_variables(njs_vm_t *vm, njs_object_prop_t *prop,
     }
 
     if (!(v->flags & NGX_STREAM_VAR_INDEXED)) {
-        njs_vm_error(vm, "variable is not writable");
+        njs_vm_type_error(vm, "variable is not writable");
         return NJS_ERROR;
     }
 
@@ -2130,7 +2132,7 @@ ngx_stream_qjs_ext_done(JSContext *cx, JSValueConst this_val, int argc,
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     status = (ngx_int_t) magic;
@@ -2146,15 +2148,14 @@ ngx_stream_qjs_ext_done(JSContext *cx, JSValueConst this_val, int argc,
         }
 
         if (status < NGX_ABORT || status > NGX_STREAM_SERVICE_UNAVAILABLE) {
-            return JS_ThrowInternalError(cx, "code is out of range");
+            return JS_ThrowRangeError(cx, "code is out of range");
         }
     }
 
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_js_module);
 
     if (ctx->filter) {
-        return JS_ThrowInternalError(cx, "should not be called while "
-                                     "filtering");
+        return JS_ThrowTypeError(cx, "should not be called while filtering");
     }
 
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, s->connection->log, 0,
@@ -2178,7 +2179,7 @@ ngx_stream_qjs_ext_log(JSContext *cx, JSValueConst this_val, int argc,
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     for (n = 0; n < argc; n++) {
@@ -2251,8 +2252,8 @@ ngx_stream_qjs_event(ngx_stream_session_t *s, JSContext *cx, JSValue name)
     }
 
     if (i == n) {
-        (void) JS_ThrowInternalError(cx, "unknown event \"%.*s\"",
-                                     (int) event.len, event.data);
+        (void) JS_ThrowTypeError(cx, "unknown event \"%.*s\"",
+                                 (int) event.len, event.data);
         JS_FreeCString(cx, (char *) event.data);
         return NULL;
     }
@@ -2264,8 +2265,8 @@ ngx_stream_qjs_event(ngx_stream_session_t *s, JSContext *cx, JSValue name)
     for (n = 0; n < NGX_JS_EVENT_MAX; n++) {
         type = ctx->events[n].data_type;
         if (type != NGX_JS_UNSET && type != events[i].data_type) {
-            (void) JS_ThrowInternalError(cx, "mixing string and buffer"
-                                         " events is not allowed");
+            (void) JS_ThrowTypeError(cx, "mixing string and buffer"
+                                     " events is not allowed");
             return NULL;
         }
     }
@@ -2284,7 +2285,7 @@ ngx_stream_qjs_ext_on(JSContext *cx, JSValueConst this_val, int argc,
 
     ses = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_STREAM_SESSION);
     if (ses == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     ctx = ngx_stream_get_module_ctx(ses->session, ngx_stream_js_module);
@@ -2295,8 +2296,8 @@ ngx_stream_qjs_ext_on(JSContext *cx, JSValueConst this_val, int argc,
     }
 
     if (JS_IsFunction(cx, ngx_qjs_arg(ctx->events[e->id].function))) {
-        return JS_ThrowInternalError(cx, "event handler \"%s\" is already set",
-                                     e->name.data);
+        return JS_ThrowTypeError(cx, "event handler \"%s\" is already set",
+                                 e->name.data);
     }
 
     if (!JS_IsFunction(cx, argv[1])) {
@@ -2322,7 +2323,7 @@ ngx_stream_qjs_ext_off(JSContext *cx, JSValueConst this_val, int argc,
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_js_module);
@@ -2348,7 +2349,7 @@ ngx_stream_qjs_ext_periodic_variables(JSContext *cx,
 
     ses = JS_GetOpaque(this_val, NGX_QJS_CLASS_ID_STREAM_PERIODIC);
     if (ses == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a periodic object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a periodic object");
     }
 
     obj = JS_NewObjectProtoClass(cx, JS_NULL, NGX_QJS_CLASS_ID_STREAM_VARS);
@@ -2371,7 +2372,7 @@ ngx_stream_qjs_ext_remote_address(JSContext *cx, JSValueConst this_val)
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     c = s->connection;
@@ -2397,7 +2398,7 @@ ngx_stream_qjs_ext_send(JSContext *cx, JSValueConst this_val, int argc,
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     c = s->connection;
@@ -2405,7 +2406,7 @@ ngx_stream_qjs_ext_send(JSContext *cx, JSValueConst this_val, int argc,
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_js_module);
 
     if (!ctx->filter) {
-        return JS_ThrowInternalError(cx, "cannot send buffer in this handler");
+        return JS_ThrowTypeError(cx, "cannot send buffer in this handler");
     }
 
     /*
@@ -2455,9 +2456,9 @@ ngx_stream_qjs_ext_send(JSContext *cx, JSValueConst this_val, int argc,
             }
 
             if (from_upstream == NGX_JS_BOOL_UNSET && ctx->buf == NULL) {
-                return JS_ThrowInternalError(cx, "from_upstream flag is "
-                                             "expected when called "
-                                             "asynchronously");
+                return JS_ThrowTypeError(cx, "from_upstream flag is "
+                                         "expected when called "
+                                         "asynchronously");
             }
         }
     }
@@ -2576,7 +2577,7 @@ out_of_memory:
 
     JS_FreeValue(cx, buf);
 
-    return JS_ThrowInternalError(cx, "memory error");
+    return JS_ThrowOutOfMemory(cx);
 }
 
 
@@ -2589,7 +2590,7 @@ ngx_stream_qjs_ext_set_return_value(JSContext *cx, JSValueConst this_val,
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     ctx = ngx_stream_get_module_ctx(s, ngx_stream_js_module);
@@ -2609,7 +2610,7 @@ ngx_stream_qjs_ext_variables(JSContext *cx, JSValueConst this_val, int type)
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     obj = JS_NewObjectProtoClass(cx, JS_NULL, NGX_QJS_CLASS_ID_STREAM_VARS);
@@ -2639,7 +2640,7 @@ ngx_stream_qjs_ext_js_var_names(JSContext *cx, JSValueConst this_val, int argc,
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     prefix = NULL;
@@ -2707,7 +2708,7 @@ ngx_stream_qjs_ext_uint(JSContext *cx, JSValueConst this_val, int offset)
 
     s = ngx_stream_qjs_session(this_val);
     if (s == NULL) {
-        return JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        return JS_ThrowTypeError(cx, "\"this\" is not a session object");
     }
 
     field = (ngx_uint_t *) ((u_char *) s + offset);
@@ -2744,7 +2745,7 @@ ngx_stream_qjs_variables_own_property(JSContext *cx,
     s = (ngx_stream_session_t *) ((uintptr_t) s & ~(uintptr_t) 1);
 
     if (s == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a session object");
         return -1;
     }
 
@@ -2805,7 +2806,7 @@ ngx_stream_qjs_variables_set_property(JSContext *cx, JSValueConst obj,
     s = (ngx_stream_session_t *) ((uintptr_t) s & ~(uintptr_t) 1);
 
     if (s == NULL) {
-        (void) JS_ThrowInternalError(cx, "\"this\" is not a session object");
+        (void) JS_ThrowTypeError(cx, "\"this\" is not a session object");
         return -1;
     }
 
@@ -2836,7 +2837,7 @@ ngx_stream_qjs_variables_set_property(JSContext *cx, JSValueConst obj,
     JS_FreeCString(cx, (char *) name.data);
 
     if (v == NULL) {
-        (void) JS_ThrowInternalError(cx, "variable not found");
+        (void) JS_ThrowTypeError(cx, "variable not found");
         return -1;
     }
 

--- a/nginx/t/js_access_body.t
+++ b/nginx/t/js_access_body.t
@@ -219,7 +219,7 @@ $t->write_file('test.js', <<EOF);
             r.variables.foo = 'no_error';
 
         } catch (e) {
-            r.variables.foo = e.message;
+            r.variables.foo = e.constructor.name + ':' + e.message;
         }
     }
 
@@ -280,7 +280,7 @@ like(http_post('/buffer_twice'), qr/var:same/,
 like(http_post('/text_then_buffer'), qr/var:same/,
 	'readRequestText then readRequestArrayBuffer same content');
 like(http_post('/concurrent_text_buffer'),
-	qr/var:request body is already being read/,
+	qr/var:TypeError:request body is already being read/,
 	'concurrent body read throws error');
 
 like(http_post_big('/big'), qr/var:10240/,

--- a/nginx/t/js_fetch_objects.t
+++ b/nginx/t/js_fetch_objects.t
@@ -239,6 +239,21 @@ $t->write_file('test.js', <<EOF);
                 h.forEach((v, k) => { r.push(`\${v}:\${k}`)})
                 return r.join('|');
              }, 'a:0, 4|c:2|q:5|z:3'],
+            ['receiver', () => {
+                try {
+                    (new Headers()).append.call({}, 'a', 'b');
+                    throw new Error('no error');
+
+                } catch (e) {
+                    if (!(e instanceof TypeError)
+                        || e.message != '"this" is not fetch headers object')
+                    {
+                        throw e;
+                    }
+                }
+
+                return 'OK';
+             }, 'OK'],
             ['set', () => {
                 var h = new Headers([['A', 'x'], ['a', 'y'], ['a', 'z']]);
                 h.set('a', '#');
@@ -376,7 +391,9 @@ $t->write_file('test.js', <<EOF);
                         throw new Error('no error');
 
                     } catch (e) {
-                        if (!e.message.startsWith(`forbidden method: \${m}`)) {
+                        if (!(e instanceof TypeError)
+                            || !e.message.startsWith(`forbidden method: \${m}`))
+                        {
                             throw e;
                         }
                     }
@@ -388,7 +405,9 @@ $t->write_file('test.js', <<EOF);
                         throw new Error('no error');
 
                     } catch (e) {
-                        if (e.message != 'invalid Request method') {
+                        if (!(e instanceof TypeError)
+                            || e.message != 'invalid Request method')
+                        {
                             throw e;
                         }
                     }
@@ -542,6 +561,22 @@ $t->write_file('test.js', <<EOF);
 
                 } catch (e) {
                     if (!e.message.startsWith('invalid Response statusText')) {
+                        throw e;
+                    }
+                }
+
+                return 'OK';
+
+             }, 'OK'],
+            ['status range', () => {
+                try {
+                    new Response(null, {status: 199});
+                    throw new Error('no error');
+
+                } catch (e) {
+                    if (!(e instanceof RangeError)
+                        || !e.message.startsWith('status provided (199) is'))
+                    {
                         throw e;
                     }
                 }

--- a/nginx/t/js_headers.t
+++ b/nginx/t/js_headers.t
@@ -62,6 +62,10 @@ http {
             js_content test.content_length_keys;
         }
 
+        location /content_length_error {
+            js_content test.content_length_error;
+        }
+
         location /content_type {
             charset windows-1251;
 
@@ -215,6 +219,16 @@ $t->write_file('test.js', <<EOF);
         r.headersOut['Content-Length'] = 3;
         var in_keys = Object.keys(r.headersOut).some(v=>v=='Content-Length');
         r.return(200, `B:\${in_keys}`);
+    }
+
+    function content_length_error(r) {
+        try {
+            r.headersOut['Content-Length'] = 'x';
+            r.return(200, 'no_error');
+
+        } catch (e) {
+            r.return(500, `\${e.constructor.name}:\${e.message}`);
+        }
     }
 
     function content_type(r) {
@@ -470,7 +484,8 @@ $t->write_file('test.js', <<EOF);
     }
 
     export default {njs:test_njs, content_length, content_length_arr,
-                    content_length_keys, content_type, content_type_arr,
+                    content_length_keys, content_length_error,
+                    content_type, content_type_arr,
                     content_encoding, content_encoding_arr, headers_list,
                     hdr_in, raw_hdr_in, hdr_sorted_keys, foo_in, ifoo_in,
                     hdr_out, raw_hdr_out, hdr_out_array, hdr_out_single,
@@ -481,7 +496,7 @@ $t->write_file('test.js', <<EOF);
 
 EOF
 
-$t->try_run('no njs')->plan(50);
+$t->try_run('no njs')->plan(51);
 
 ###############################################################################
 
@@ -506,6 +521,9 @@ unlike(http_get('/hdr_out?foo'), qr/Foo:/, 'r.headersOut no value 2');
 like(http_get('/content_length_keys'), qr/B:true/, 'Content-Length in keys');
 like(http_get('/content_length_arr'), qr/Content-Length: 3/,
 	'set Content-Length arr');
+like(http_get('/content_length_error'),
+	qr/500.*TypeError:failed converting argument to positive integer/s,
+	'set invalid Content-Length');
 
 like(http_get('/content_type'), qr/B:true/, 'Content-Type in keys');
 like(http_get('/content_type_arr'), qr/Content-Type: text\/html/,

--- a/nginx/t/js_request_form.t
+++ b/nginx/t/js_request_form.t
@@ -208,7 +208,7 @@ $t->write_file('test.js', <<'EOF');
             r.return(200, 'no_error');
 
         } catch (e) {
-            r.return(500, e.message);
+            r.return(500, `${e.constructor.name}:${e.message}`);
         }
     }
 
@@ -375,19 +375,19 @@ unlike(http_post_form('/content_form', $fake_boundary),
     'fake multipart boundary does not restart header parsing');
 
 like(http_post_form('/content_form_error', urlencoded_form('a=%')),
-    qr/500.*malformed percent escape/s,
+    qr/500.*TypeError:malformed percent escape/s,
     'urlencoded bare % at end is rejected');
 
 like(http_post_form('/content_form_error', urlencoded_form('a=%4')),
-    qr/500.*malformed percent escape/s,
+    qr/500.*TypeError:malformed percent escape/s,
     'urlencoded %X with missing second digit is rejected');
 
 like(http_post_form('/content_form_error', urlencoded_form('a=%gg')),
-    qr/500.*malformed percent escape/s,
+    qr/500.*TypeError:malformed percent escape/s,
     'urlencoded non-hex percent escape is rejected');
 
 like(http_post_form('/content_form_error', urlencoded_form('%Z=1')),
-    qr/500.*malformed percent escape/s,
+    qr/500.*TypeError:malformed percent escape/s,
     'urlencoded malformed percent escape in name is rejected');
 
 like(http_post_form('/content_form_error', ['text/plain', 'a=1']),
@@ -404,7 +404,7 @@ like(http_post_raw('/content_form_error', 'a=1'),
 
 like(http_post_form('/content_form_error',
     ['application/x-www-form-urlencoded; =x', 'a=1']),
-    qr/500.*malformed parameter/s,
+    qr/500.*TypeError:malformed parameter/s,
     'malformed content type parameter is rejected');
 
 like(http_post_form('/content_form_error', ['multipart/form-data', 'a=1']),
@@ -413,39 +413,39 @@ like(http_post_form('/content_form_error', ['multipart/form-data', 'a=1']),
 
 like(http_post_form('/content_form_error',
     ['multipart/form-data; boundary=""', '']),
-    qr/500.*(invalid multipart boundary|empty parameter value)/s,
+    qr/500.*TypeError:(invalid multipart boundary|empty parameter value)/s,
     'empty quoted multipart boundary is rejected');
 
 like(http_post_form('/content_form_error',
     ["multipart/form-data; boundary=" . 'x' x 201, '']),
-    qr/500.*invalid multipart boundary/s,
+    qr/500.*TypeError:invalid multipart boundary/s,
     'multipart boundary over 200 bytes is rejected');
 
 like(http_post_form('/content_form_error',
     ['multipart/form-data; boundary=X; boundary=Y', '--X--']),
-    qr/500.*duplicate boundary parameter/s,
+    qr/500.*TypeError:duplicate boundary parameter/s,
     'duplicate multipart boundary parameter is rejected');
 
 like(http_post_form('/content_form_error',
     ['multipart/form-data; boundary=X junk', '--X--']),
-    qr/500.*(malformed content type|malformed parameter)/s,
+    qr/500.*TypeError:(malformed content type|malformed parameter)/s,
     'malformed trailing content type parameter data is rejected');
 
 like(http_post_form('/content_form_error',
     ['multipart/form-data; boundary=XXX', '--XXXjunk']),
-    qr/500.*malformed multipart boundary/s,
+    qr/500.*TypeError:malformed multipart boundary/s,
     'multipart opening delimiter without CRLF is rejected');
 
 like(http_post_form('/content_form_error',
     ['multipart/form-data; boundary=XXX', '-']),
-    qr/500.*malformed multipart body/s,
+    qr/500.*TypeError:malformed multipart body/s,
     'short multipart body without boundary marker is rejected');
 
 like(http_post_form('/content_form_error',
     ['multipart/form-data; boundary=X',
      '--X' . CRLF
      . 'Content-Disposition: form-data; name="a"']),
-    qr/500.*missing multipart header separator/s,
+    qr/500.*TypeError:missing multipart header separator/s,
     'multipart part without header separator is rejected');
 
 like(http_post_form('/content_form_error',
@@ -454,7 +454,7 @@ like(http_post_form('/content_form_error',
      . 'X-Large: ' . ('a' x 17000) . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*multipart headers are too large/s,
+    qr/500.*TypeError:multipart headers are too large/s,
     'multipart header block size limit is enforced');
 
 like(http_post_form('/content_form_error',
@@ -464,7 +464,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data; name="a"' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*multipart header line is too long/s,
+    qr/500.*TypeError:multipart header line is too long/s,
     'multipart header line size limit is enforced');
 
 my $many_headers = join('', map { "X-$_: v" . CRLF } 1 .. 33);
@@ -476,7 +476,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data; name="a"' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*too many multipart headers/s,
+    qr/500.*TypeError:too many multipart headers/s,
     'multipart header count limit is enforced');
 
 like(http_post_form('/content_form_error',
@@ -485,7 +485,7 @@ like(http_post_form('/content_form_error',
      . 'X-Other: foo' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*missing Content-Disposition header/s,
+    qr/500.*TypeError:missing Content-Disposition header/s,
     'multipart part without Content-Disposition is rejected');
 
 like(http_post_form('/content_form_error',
@@ -495,7 +495,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data; name="b"' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*duplicate Content-Disposition header/s,
+    qr/500.*TypeError:duplicate Content-Disposition header/s,
     'duplicate multipart Content-Disposition header is rejected');
 
 like(http_post_form('/content_form_error',
@@ -504,7 +504,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: attachment; name="a"' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*unsupported disposition type/s,
+    qr/500.*TypeError:unsupported disposition type/s,
     'unsupported multipart disposition type is rejected');
 
 like(http_post_form('/content_form_error',
@@ -513,7 +513,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*multipart field name is required/s,
+    qr/500.*TypeError:multipart field name is required/s,
     'multipart Content-Disposition without name is rejected');
 
 like(http_post_form('/content_form_error',
@@ -523,7 +523,7 @@ like(http_post_form('/content_form_error',
      . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*malformed Content-Disposition/s,
+    qr/500.*TypeError:malformed Content-Disposition/s,
     'multipart Content-Disposition trailing data is rejected');
 
 like(http_post_form('/content_form_error',
@@ -533,7 +533,7 @@ like(http_post_form('/content_form_error',
      . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*duplicate name parameter/s,
+    qr/500.*TypeError:duplicate name parameter/s,
     'duplicate multipart name parameter is rejected');
 
 like(http_post_form('/content_form_error',
@@ -543,7 +543,7 @@ like(http_post_form('/content_form_error',
      . 'filename="y"' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*duplicate filename parameter/s,
+    qr/500.*TypeError:duplicate filename parameter/s,
     'duplicate multipart filename parameter is rejected');
 
 like(http_post_form('/content_form_error',
@@ -552,7 +552,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data; name' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*malformed parameter/s,
+    qr/500.*TypeError:malformed parameter/s,
     'multipart parameter without equals is rejected');
 
 like(http_post_form('/content_form_error',
@@ -561,7 +561,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data; name=' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*empty parameter value/s,
+    qr/500.*TypeError:empty parameter value/s,
     'multipart parameter with empty unquoted value is rejected');
 
 like(http_post_form('/content_form_error',
@@ -571,7 +571,7 @@ like(http_post_form('/content_form_error',
      . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*unterminated quoted parameter/s,
+    qr/500.*TypeError:unterminated quoted parameter/s,
     'multipart trailing backslash in quoted parameter is rejected');
 
 like(http_post_form('/content_form_error',
@@ -581,7 +581,7 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data; name="a"' . CRLF . CRLF
      . 'data' . CRLF
      . '--X--']),
-    qr/500.*malformed multipart header/s,
+    qr/500.*TypeError:malformed multipart header/s,
     'multipart header line without colon is rejected');
 
 like(http_post_form('/content_form_error',
@@ -590,12 +590,12 @@ like(http_post_form('/content_form_error',
      . 'Content-Disposition: form-data; name="a"' . CRLF . CRLF
      . 'data' . CRLF
      . '--Xjunk']),
-    qr/500.*malformed multipart boundary/s,
+    qr/500.*TypeError:malformed multipart boundary/s,
     'malformed multipart boundary after part is rejected');
 
 like(http_post_form('/content_form_error',
     ['multipart/form-data; boundary=XXX', 'no boundary here at all']),
-    qr/500.*malformed multipart body/s,
+    qr/500.*TypeError:malformed multipart body/s,
     'multipart body without boundary marker is rejected');
 
 like(http_post_form('/content_form_error',
@@ -603,11 +603,11 @@ like(http_post_form('/content_form_error',
      '--X' . CRLF
      . 'Content-Disposition: form-data; name="a"' . CRLF . CRLF
      . 'value with no terminating boundary']),
-    qr/500.*truncated multipart body/s,
+    qr/500.*TypeError:truncated multipart body/s,
     'multipart body without closing boundary is rejected');
 
 like(http_post_form('/content_form_limit', urlencoded_form('a=1&b=2')),
-    qr/500.*maxKeys limit exceeded/s, 'maxKeys limit breach rejects');
+    qr/500.*TypeError:maxKeys limit exceeded/s, 'maxKeys limit breach rejects');
 
 like(http_post_form('/content_form_limit', urlencoded_form('&a=1&&')),
     qr/200.*no_error/s, 'urlencoded empty fields do not count for maxKeys');
@@ -615,7 +615,7 @@ like(http_post_form('/content_form_limit', urlencoded_form('&a=1&&')),
 like(http_post_form('/content_form_limit',
     multipart_form({ name => 'a', value => '1' },
                    { name => 'b', value => '2' })),
-    qr/500.*maxKeys limit exceeded/s,
+    qr/500.*TypeError:maxKeys limit exceeded/s,
     'multipart maxKeys limit breach rejects');
 
 ###############################################################################

--- a/nginx/t/js_variables.t
+++ b/nginx/t/js_variables.t
@@ -108,7 +108,8 @@ $t->try_run('no njs')->plan(5);
 
 like(http_get('/var_set?a=bar'), qr/test_varbar/, 'var set');
 like(http_get('/content_set?a=bar'), qr/bar/, 'content set');
-like(http_get('/not_found_set'), qr/variable not found/, 'not found exception');
+like(http_get('/not_found_set'), qr/TypeError: variable not found/,
+	'not found exception');
 like(http_get('/variable_lowkey'), qr/X{16}/,
 	'variable name is not overwritten while reading');
 like(http_get('/variable_lowkey?set=1'), qr/X{16}/,

--- a/nginx/t/stream_js.t
+++ b/nginx/t/stream_js.t
@@ -70,6 +70,11 @@ stream {
     js_set $js_async         test.asyncf;
     js_set $js_async_direct  test.asyncf_direct;
     js_set $js_buffer        test.buffer;
+    js_set $js_done_range    test.done_range;
+    js_set $js_event_unknown test.event_unknown;
+    js_set $js_event_dup     test.event_dup;
+    js_set $js_send_state    test.send_state;
+    js_set $js_var_not_found test.var_not_found;
 
     js_import test.js;
 
@@ -201,6 +206,31 @@ stream {
     server {
         listen      127.0.0.1:8101;
         return      $js_buffer;
+    }
+
+    server {
+        listen      127.0.0.1:8103;
+        return      $js_done_range;
+    }
+
+    server {
+        listen      127.0.0.1:8104;
+        return      $js_event_unknown;
+    }
+
+    server {
+        listen      127.0.0.1:8105;
+        return      $js_event_dup;
+    }
+
+    server {
+        listen      127.0.0.1:8106;
+        return      $js_send_state;
+    }
+
+    server {
+        listen      127.0.0.1:8107;
+        return      $js_var_not_found;
     }
 }
 
@@ -397,17 +427,51 @@ $t->write_file('test.js', <<EOF);
         return `retval: \${a1 + a2}`;
     }
 
+    function error_name(fn) {
+        try {
+            fn();
+            return 'no_error';
+
+        } catch (e) {
+            return `\${e.constructor.name}:\${e.message}`;
+        }
+    }
+
+    function done_range(s) {
+        return error_name(() => s.done(-999));
+    }
+
+    function event_unknown(s) {
+        return error_name(() => s.on('unknown', () => {}));
+    }
+
+    function event_dup(s) {
+        return error_name(() => {
+            s.on('upload', () => {});
+            s.on('upload', () => {});
+        });
+    }
+
+    function send_state(s) {
+        return error_name(() => s.send('x'));
+    }
+
+    function var_not_found(s) {
+        return error_name(() => { s.variables.unknown = 1 });
+    }
+
     export default {njs:test_njs, addr, variable, sess_unk, log, access_step,
                     preread_step, filter_step, access_undecided, access_allow,
                     access_deny, preread_async, preread_data, preread_req_line,
                     req_line, filter_empty, filter_header_inject, filter_search,
                     access_except, preread_except, filter_except, asyncf,
-                    asyncf_direct, buffer};
+                    asyncf_direct, buffer, done_range, event_unknown,
+                    event_dup, send_state, var_not_found};
 
 EOF
 
 $t->run_daemon(\&stream_daemon, port(8090));
-$t->try_run('no stream njs available')->plan(25);
+$t->try_run('no stream njs available')->plan(30);
 $t->waitforsocket('127.0.0.1:' . port(8090));
 
 ###############################################################################
@@ -452,6 +516,19 @@ like(stream('127.0.0.1:' . port(8101))->read(), qr/\xaa\xbb\xcc\xdd/,
 	'buffer variable');
 
 }
+
+is(stream('127.0.0.1:' . port(8103))->read(),
+	'RangeError:code is out of range', 's.done code range');
+like(stream('127.0.0.1:' . port(8104))->read(),
+	qr/^TypeError:unknown event "unknown"/, 's.on unknown event');
+like(stream('127.0.0.1:' . port(8105))->read(),
+	qr/^TypeError:event handler "upload" is already set/,
+	's.on duplicate handler');
+is(stream('127.0.0.1:' . port(8106))->read(),
+	'TypeError:cannot send buffer in this handler',
+	's.send wrong handler');
+is(stream('127.0.0.1:' . port(8107))->read(),
+	'TypeError:variable not found', 's.variables unknown set');
 
 $t->stop();
 

--- a/nginx/t/stream_js_buffer.t
+++ b/nginx/t/stream_js_buffer.t
@@ -123,7 +123,7 @@ $t->write_file('test.js', <<EOF);
             s.on('upload', () => {});
             s.on('downstream', () => {});
         } catch (e) {
-            throw new Error(`cb_mismatch:\${e.message}`)
+            throw new Error(`cb_mismatch:\${e.constructor.name}:\${e.message}`)
         }
     }
 
@@ -132,7 +132,7 @@ $t->write_file('test.js', <<EOF);
             s.on('upstream', () => {});
             s.on('download', () => {});
         } catch (e) {
-            throw new Error(`cb_mismatch2:\${e.message}`)
+            throw new Error(`cb_mismatch2:\${e.constructor.name}:\${e.message}`)
         }
     }
 
@@ -192,10 +192,12 @@ is(stream('127.0.0.1:' . port(8086))->io('x', length => 6), 'ellllo',
 
 $t->stop();
 
-ok(index($t->read_file('error.log'), 'cb_mismatch:mixing string and buffer')
-   > 0, 'cb mismatch');
-ok(index($t->read_file('error.log'), 'cb_mismatch2:mixing string and buffer')
-   > 0, 'cb mismatch');
+ok(index($t->read_file('error.log'),
+	'cb_mismatch:TypeError:mixing string and buffer') > 0,
+	'cb mismatch');
+ok(index($t->read_file('error.log'),
+	'cb_mismatch2:TypeError:mixing string and buffer') > 0,
+	'cb mismatch');
 
 ###############################################################################
 

--- a/src/qjs.c
+++ b/src/qjs.c
@@ -742,7 +742,7 @@ qjs_text_decoder_decode(JSContext *cx, JSValueConst this_val, int argc,
 
     td = JS_GetOpaque(this_val, QJS_CORE_CLASS_ID_TEXT_DECODER);
     if (td == NULL) {
-        return JS_ThrowInternalError(cx, "'this' is not a TextDecoder");
+        return JS_ThrowTypeError(cx, "'this' is not a TextDecoder");
     }
 
     ret = qjs_typed_array_data(cx, argv[0], &data);
@@ -802,7 +802,7 @@ qjs_text_decoder_encoding(JSContext *ctx, JSValueConst this_val)
 
     td = JS_GetOpaque(this_val, QJS_CORE_CLASS_ID_TEXT_DECODER);
     if (td == NULL) {
-        return JS_ThrowInternalError(ctx, "'this' is not a TextDecoder");
+        return JS_ThrowTypeError(ctx, "'this' is not a TextDecoder");
     }
 
     switch (td->encoding) {
@@ -821,7 +821,7 @@ qjs_text_decoder_fatal(JSContext *ctx, JSValueConst this_val)
 
     td = JS_GetOpaque(this_val, QJS_CORE_CLASS_ID_TEXT_DECODER);
     if (td == NULL) {
-        return JS_ThrowInternalError(ctx, "'this' is not a TextDecoder");
+        return JS_ThrowTypeError(ctx, "'this' is not a TextDecoder");
     }
 
     return JS_NewBool(ctx, td->fatal);
@@ -835,7 +835,7 @@ qjs_text_decoder_ignore_bom(JSContext *ctx, JSValueConst this_val)
 
     td = JS_GetOpaque(this_val, QJS_CORE_CLASS_ID_TEXT_DECODER);
     if (td == NULL) {
-        return JS_ThrowInternalError(ctx, "'this' is not a TextDecoder");
+        return JS_ThrowTypeError(ctx, "'this' is not a TextDecoder");
     }
 
     return JS_NewBool(ctx, td->ignore_bom);
@@ -915,7 +915,7 @@ qjs_text_encoder_encode(JSContext *cx, JSValueConst this_val, int argc,
 
     te = JS_GetOpaque(this_val, QJS_CORE_CLASS_ID_TEXT_ENCODER);
     if (te == NULL) {
-        return JS_ThrowInternalError(cx, "'this' is not a TextEncoder");
+        return JS_ThrowTypeError(cx, "'this' is not a TextEncoder");
     }
 
     if (!JS_IsString(argv[0])) {
@@ -986,7 +986,7 @@ qjs_text_encoder_encode_into(JSContext *cx, JSValueConst this_val, int argc,
 
     te = JS_GetOpaque(this_val, QJS_CORE_CLASS_ID_TEXT_ENCODER);
     if (te == NULL) {
-        return JS_ThrowInternalError(cx, "'this' is not a TextEncoder");
+        return JS_ThrowTypeError(cx, "'this' is not a TextEncoder");
     }
 
     if (!JS_IsString(argv[0])) {

--- a/test/xml/xml.t.mjs
+++ b/test/xml/xml.t.mjs
@@ -366,6 +366,18 @@ let modify_tsuite = {
             return xml.serializeToString(doc);
           },
           expected: `<note><to a="foo" b="bar">Tove</to><from>Jani</from></note>` },
+        { get: (doc) => {
+            try {
+                doc.note.$tag$xxx = doc.note.to;
+            } catch (e) {
+                if (e instanceof TypeError) {
+                    return 'OK';
+                }
+            }
+
+            throw Error('unexpected exception');
+          },
+          expected: 'OK' },
         { doc: `<root><a>A</a><b>B</b><a>C</a></root>`,
           get: (doc) => {
             doc.$root.removeChildren('a');


### PR DESCRIPTION
Cleaning up of exception classes for QuickJS/njs integration code + small fixes found.  The goal is not to rewrite
all messages, but to make exception classes predictable while keeping real bug fixes visible for review and backports.

- Wrong receiver and wrong user-visible API usage are `TypeError`.
- Numeric/status bounds violations are `RangeError`.
- Host/runtime failures remain `InternalError`.
- Allocation-only failures use memory errors / `OutOfMemory`.
- Correctness fixes are split from pure exception-class retyping when the split is small and clear.

## Correctness fixes split out

- Fetch QuickJS conversion handling:
  - preserve exceptions already raised by QuickJS conversions;
  - add `JS_HasException()` / `JS_ThrowOutOfMemory()` guards where `ngx_qjs_string()` can fail silently on pool allocation;
  - use `JS_GetOpaque()` instead of `JS_GetOpaque2()` where class mismatch is a normal miss, avoiding stale pending exceptions;
  - free the headers init value before throwing for non-object `Headers`.
- HTTP njs handlers:
  - set pending exceptions before returning `NJS_ERROR` from response output paths such as `sendHeader()`, `send()`, and `finish()`.
- Stream variables:
  - clear `vv->valid` and set memory error when stream variable storage allocation fails.

## Exception-class changes

- Fetch, HTTP, Stream, XML, and common helper code now use `TypeError` for receiver/API misuse.
- Fetch/HTTP/Stream status and code range checks use `RangeError`.
- XML parse failures use `SyntaxError`.
- Internal nginx/output/body collection failures remain `InternalError`.
- `ngx_js_ext_log()` / `ngx_qjs_ext_log()` missing external receiver/context is treated as `TypeError`, matching the wrong-receiver policy.
- Stream `s.done()` while filtering is treated as `TypeError`, matching other wrong-phase user API calls.

## Deliberate non-goals

- Shared dictionary exception alignment is not included as it requires additional work
- Existing generic conversion messages in HTTP/Stream handlers are mostly kept to avoid unnecessary user-visible churn.
- No extra minor receiver tests were added just to exercise every retyped branch.

