### PR TITLE
HTTP: fixed use-after-free in subrequest completion handler.

### DIFF
--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -5044,7 +5044,14 @@ ngx_http_js_subrequest_done(ngx_http_request_t *r, void *data, ngx_int_t rc)
 
     ngx_js_del_event(ctx, event);
 
-    ngx_http_js_event_finalize(r->parent, NGX_OK);
+    /*
+     * A post_subrequest handler runs inside ngx_http_finalize_request()
+     * of the subrequest; do not run posted requests here: the parent may
+     * terminate the main request and free the shared request pool.
+     */
+    if (ngx_http_post_request(r->parent, NULL) != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     return NGX_OK;
 }
@@ -7604,7 +7611,14 @@ ngx_http_qjs_subrequest_done(ngx_http_request_t *r, void *data, ngx_int_t rc)
     JS_FreeValue(cx, reply);
     ngx_js_del_event(ctx, event);
 
-    ngx_http_js_event_finalize(r->parent, NGX_OK);
+    /*
+     * A post_subrequest handler runs inside ngx_http_finalize_request()
+     * of the subrequest; do not run posted requests here: the parent may
+     * terminate the main request and free the shared request pool.
+     */
+    if (ngx_http_post_request(r->parent, NULL) != NGX_OK) {
+        return NGX_ERROR;
+    }
 
     return NGX_OK;
 }


### PR DESCRIPTION
ngx_http_js_subrequest_done() and ngx_http_qjs_subrequest_done() are post_subrequest handlers, so nginx calls them from within ngx_http_finalize_request() of the subrequest and continues to use the subrequest and its main request after the handler returns.

Previously, the handlers woke the parent request synchronously via ngx_http_js_event_finalize(), which runs posted requests.  This re-entered request processing while the subrequest was still being finalized.  In particular, when the subrequest's proxied upstream closed the connection prematurely and the client had disconnected as well, the error response write to the client failed and the main request was terminated.  That freed the request pool shared by all requests of the connection while ngx_http_finalize_request() of the subrequest was still using it, and the worker process crashed (use-after-free).

Now the parent request is only posted, and it is run by the event handler that finalized the subrequest, the same way ngx_http_finalize_request() itself wakes a subrequest's parent.  If posting fails, NGX_ERROR is returned so that the request is terminated instead of leaving the parent stuck.

This closes #1077

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
