### PR TITLE
Modules: fix SharedDict.pop() for unexpired keys in timeout zones

### DIFF
--- a/nginx/ngx_js_shared_dict.c
+++ b/nginx/ngx_js_shared_dict.c
@@ -1429,6 +1429,20 @@ ngx_js_dict_node_free(ngx_js_dict_t *dict, ngx_js_dict_node_t *node)
 }
 
 
+static ngx_rbtree_key_t
+ngx_js_dict_expire_unlink(ngx_js_dict_t *dict, ngx_js_dict_node_t *node)
+{
+    ngx_rbtree_key_t  expire;
+
+    /* ngx_rbtree_delete() clears the node key. */
+    expire = node->expire.key;
+
+    ngx_rbtree_delete(&dict->sh->rbtree_expire, &node->expire);
+
+    return expire;
+}
+
+
 static ngx_int_t
 ngx_js_dict_set(njs_vm_t *vm, ngx_js_dict_t *dict, ngx_str_t *key,
     njs_value_t *value, ngx_msec_t timeout, unsigned flags)
@@ -1618,6 +1632,7 @@ ngx_js_dict_delete(njs_vm_t *vm, ngx_js_dict_t *dict, ngx_str_t *key,
     ngx_int_t            rc;
     ngx_msec_t           now;
     ngx_time_t          *tp;
+    ngx_rbtree_key_t     expire;
     ngx_js_dict_node_t  *node;
 
     ngx_rwlock_wlock(&dict->sh->rwlock);
@@ -1629,8 +1644,10 @@ ngx_js_dict_delete(njs_vm_t *vm, ngx_js_dict_t *dict, ngx_str_t *key,
         return NGX_DECLINED;
     }
 
+    expire = 0;
+
     if (dict->timeout) {
-        ngx_rbtree_delete(&dict->sh->rbtree_expire, &node->expire);
+        expire = ngx_js_dict_expire_unlink(dict, node);
     }
 
     ngx_rbtree_delete(&dict->sh->rbtree, (ngx_rbtree_node_t *) node);
@@ -1639,7 +1656,7 @@ ngx_js_dict_delete(njs_vm_t *vm, ngx_js_dict_t *dict, ngx_str_t *key,
         tp = ngx_timeofday();
         now = tp->sec * 1000 + tp->msec;
 
-        if (!dict->timeout || now < node->expire.key) {
+        if (!dict->timeout || now < expire) {
             rc = ngx_js_dict_copy_value_locked(vm, dict, node, retval);
 
         } else {
@@ -4041,6 +4058,7 @@ ngx_qjs_dict_delete(JSContext *cx, ngx_js_dict_t *dict, ngx_str_t *key,
     JSValue              ret;
     ngx_msec_t           now;
     ngx_time_t          *tp;
+    ngx_rbtree_key_t     expire;
     ngx_js_dict_node_t  *node;
 
     ngx_rwlock_wlock(&dict->sh->rwlock);
@@ -4052,8 +4070,10 @@ ngx_qjs_dict_delete(JSContext *cx, ngx_js_dict_t *dict, ngx_str_t *key,
         return JS_UNDEFINED;
     }
 
+    expire = 0;
+
     if (dict->timeout) {
-        ngx_rbtree_delete(&dict->sh->rbtree_expire, &node->expire);
+        expire = ngx_js_dict_expire_unlink(dict, node);
     }
 
     ngx_rbtree_delete(&dict->sh->rbtree, (ngx_rbtree_node_t *) node);
@@ -4062,7 +4082,7 @@ ngx_qjs_dict_delete(JSContext *cx, ngx_js_dict_t *dict, ngx_str_t *key,
         tp = ngx_timeofday();
         now = tp->sec * 1000 + tp->msec;
 
-        if (!dict->timeout || now < node->expire.key) {
+        if (!dict->timeout || now < expire) {
             ret = ngx_qjs_dict_copy_value_locked(cx, dict, node);
 
         } else {

--- a/nginx/t/js_shared_dict.t
+++ b/nginx/t/js_shared_dict.t
@@ -356,7 +356,7 @@ EOF
 
 $t->try_run('no js_shared_dict_zone');
 
-$t->plan(59);
+$t->plan(61);
 
 ###############################################################################
 
@@ -482,6 +482,11 @@ ok($ttl_incr_def >= 900000 && $ttl_incr_def <= 1000000,
 
 like(http_get('/pop?dict=bar&key=FOO'), qr/zzz/, 'pop bar.FOO');
 like(http_get('/pop?dict=bar&key=FOO'), qr/undefined/, 'pop deleted bar.FOO');
+
+http_get('/set?dict=foo&key=POP&value=alive');
+like(http_get('/pop?dict=foo&key=POP'), qr/alive/, 'pop unexpired foo.POP');
+like(http_get('/pop?dict=foo&key=POP'), qr/undefined/, 'pop deleted foo.POP');
+
 http_get('/set?dict=foo&key=BAR&value=xxx');
 like(http_get('/clear?dict=foo'), qr/undefined/, 'clear foo');
 


### PR DESCRIPTION
# Proposed changes

## Problem

`SharedDict.pop()` returns `undefined` for **unexpired** entries in zones declared with `timeout=` — the entry is deleted, but its value is lost. Both engines are affected (njs VM and QuickJS). Present in current master.

Runtime probe against a `timeout=5m` zone (from a production OIDC deployment where every login callback failed because session states live in a timeout zone):

```
add=true  get=alive  pop=undefined  get_after_pop=undefined
```

## Root cause

`ngx_js_dict_delete()` (and `ngx_qjs_dict_delete()`) removes the node from the expire rbtree **before** evaluating expiration:

```c
if (dict->timeout) {
    ngx_rbtree_delete(&dict->sh->rbtree_expire, &node->expire);
}

ngx_rbtree_delete(&dict->sh->rbtree, (ngx_rbtree_node_t *) node);

if (retval != NULL) {
    ...
    if (!dict->timeout || now < node->expire.key) {   /* already poisoned */
```

nginx core `ngx_rbtree_delete()` poisons the removed node unconditionally — `node->key = 0`, `left/right/parent = NULL` (the `/* DEBUG stuff */` block is not behind an `NGX_DEBUG` guard). So `node->expire.key` is already `0` when the comparison runs, `now < node->expire.key` is always false, the helper returns `NGX_DECLINED`, and `pop()` maps that to `undefined`.

Scope: only `pop()` — the other callers of the same helper pass `retval = NULL`, so the bogus expire check never runs; and only zones with `timeout=` — otherwise `!dict->timeout` short-circuits. `get()`/`delete()`/`set()`/`incr()` are unaffected.

## Fix

Snapshot `node->expire.key` into a local variable before the rbtree removal, and compare against the snapshot — in both `ngx_js_dict_delete()` and `ngx_qjs_dict_delete()`. nginx core's key zeroing is legitimate node poisoning; njs must not read the field after removal.

## Tests

`nginx/t/js_shared_dict.t` previously covered "pop **expired** key from a timeout zone" (`zone=foo`, `timeout=2s`) and "pop **unexpired** key from a no-timeout zone" (`zone=bar`) — but never "pop **unexpired** key from a **timeout** zone". Added the missing pair:

```perl
http_get('/set?dict=foo&key=POP&value=alive');
like(http_get('/pop?dict=foo&key=POP'), qr/alive/, 'pop unexpired foo.POP');
like(http_get('/pop?dict=foo&key=POP'), qr/undefined/, 'pop deleted foo.POP');
```

## Verification

Minimal reproduction (runs in one minute):

`nginx.conf`:

```nginx
events {}
http {
    js_import probe from probe.js;
    js_shared_dict_zone zone=foo:1M timeout=5m;

    server {
        listen 127.0.0.1:8080;
        location /t { js_content probe.t; }
    }
}
```

`probe.js`:

```js
function t(r) {
    ngx.shared.foo.add('k', 'alive');
    var g = ngx.shared.foo.get('k');
    var p = ngx.shared.foo.pop('k');
    var g2 = ngx.shared.foo.get('k');
    r.return(200, `get=${g} pop=${p} get_after=${g2}\n`);
}
export default { t };
```

```
$ curl http://127.0.0.1:8080/t
get=alive pop=undefined get_after=undefined   # before the fix
get=alive pop=alive get_after=undefined       # after the fix
```

(Repeated curls print the same line: each request re-adds the key that the previous pop deleted.)

Verified on macOS/arm64 and Linux/amd64 (Debian 12, nginx 1.30.4). The new `pop unexpired foo.POP` test fails without the fix, while the full `js_shared_dict.t` suite passes with it. The patched Linux module also restores the OIDC callback flow that originally exposed the issue.

The QuickJS path is patched identically and verified at runtime with `js_engine qjs` on nginx 1.30.4 — `pop()` correctly returns unexpired values from a `timeout=` zone with both QuickJS flavors (quickjs-ng v0.9.0 and bellard quickjs-2026-06-04). The `js_shared_dict.t` suite itself runs the default njs VM engine.

### Checklist

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginx/njs/blob/master/CONTRIBUTING.md) document.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have checked that the relevant tests pass after adding the changes.
