### PR TITLE
Buffer: fix use-after-free on detach during argument coercion

### DIFF
--- a/src/njs_buffer.c
+++ b/src/njs_buffer.c
@@ -675,43 +675,43 @@ njs_value_buffer_get(njs_vm_t *vm, njs_value_t *value, njs_str_t *dst)
 
 
 static njs_int_t
-njs_buffer_array_range(njs_vm_t *vm, njs_typed_array_t *array,
-    const njs_value_t *start, const njs_value_t *end, const char *name,
-    uint8_t **out_start, uint8_t **out_end)
+njs_buffer_range_index(njs_vm_t *vm, const njs_value_t *value, uint64_t *out)
 {
-    uint64_t            num_start, num_end;
-    njs_int_t           ret;
+    if (njs_is_defined(value)) {
+        return njs_value_to_index(vm, njs_value_arg(value), out);
+    }
+
+    return NJS_OK;
+}
+
+
+/*
+ * Applies an already-resolved [num_start, num_end) range to array.  The
+ * array's buffer is fetched, and revalidated as non-detached, here, after
+ * any njs_value_to_index() coercion of the range bounds performed by the
+ * caller, so that a user callback triggered by that coercion cannot leave
+ * the resulting out_start and out_end pointing into a buffer that has
+ * since been detached.  has_end == 0 means "use array->byte_length" for
+ * num_end.
+ */
+
+static njs_int_t
+njs_buffer_apply_range(njs_vm_t *vm, njs_typed_array_t *array,
+    uint64_t num_start, uint64_t num_end, njs_bool_t has_end,
+    njs_bool_t writable, const char *name, uint8_t **out_start,
+    uint8_t **out_end)
+{
     njs_array_buffer_t  *buffer;
-
-    num_start = 0;
-
-    if (njs_slow_path(njs_is_detached_buffer(array->buffer))) {
-        njs_type_error(vm, "detached buffer");
-        return NJS_ERROR;
-    }
-
-    if (njs_is_defined(start)) {
-        ret = njs_value_to_index(vm, njs_value_arg(start), &num_start);
-        if (njs_slow_path(ret != NJS_OK)) {
-            return ret;
-        }
-    }
 
     if (num_start > array->byte_length) {
         njs_range_error(vm, "\"%sStart\" is out of range: %L", name, num_start);
         return NJS_ERROR;
     }
 
-    num_end = array->byte_length;
+    if (!has_end) {
+        num_end = array->byte_length;
 
-    if (njs_is_defined(end)) {
-        ret = njs_value_to_index(vm, njs_value_arg(end), &num_end);
-        if (njs_slow_path(ret != NJS_OK)) {
-            return ret;
-        }
-    }
-
-    if (num_end > array->byte_length) {
+    } else if (num_end > array->byte_length) {
         njs_range_error(vm, "\"%sEnd\" is out of range: %L", name, num_end);
         return NJS_ERROR;
     }
@@ -720,7 +720,21 @@ njs_buffer_array_range(njs_vm_t *vm, njs_typed_array_t *array,
         num_end = num_start;
     }
 
-    buffer = njs_typed_array_buffer(array);
+    if (writable) {
+        buffer = njs_typed_array_writable(vm, array);
+        if (njs_slow_path(buffer == NULL)) {
+            return NJS_ERROR;
+        }
+
+    } else {
+        buffer = array->buffer;
+
+        if (njs_slow_path(njs_is_detached_buffer(buffer))) {
+            njs_type_error(vm, "detached buffer");
+            return NJS_ERROR;
+        }
+    }
+
     *out_start = &buffer->u.u8[array->offset + num_start];
     *out_end = &buffer->u.u8[array->offset + num_end];
 
@@ -736,6 +750,8 @@ njs_buffer_compare_array(njs_vm_t *vm, njs_value_t *val1, njs_value_t *val2,
 {
     size_t             size, src_size, trg_size;
     uint8_t            *src, *src_end, *trg, *trg_end;
+    uint64_t           num_target_start, num_target_end, num_source_start,
+                       num_source_end;
     njs_int_t          ret;
     njs_typed_array_t  *source, *target;
 
@@ -749,13 +765,41 @@ njs_buffer_compare_array(njs_vm_t *vm, njs_value_t *val1, njs_value_t *val2,
         return NJS_ERROR;
     }
 
-    ret = njs_buffer_array_range(vm, target, target_start, target_end, "target",
+    num_target_start = 0;
+    num_target_end = 0;
+
+    ret = njs_buffer_range_index(vm, target_start, &num_target_start);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    ret = njs_buffer_range_index(vm, target_end, &num_target_end);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    num_source_start = 0;
+    num_source_end = 0;
+
+    ret = njs_buffer_range_index(vm, source_start, &num_source_start);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    ret = njs_buffer_range_index(vm, source_end, &num_source_end);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    ret = njs_buffer_apply_range(vm, target, num_target_start, num_target_end,
+                                 njs_is_defined(target_end), 0, "target",
                                  &trg, &trg_end);
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
 
-    ret = njs_buffer_array_range(vm, source, source_start, source_end, "source",
+    ret = njs_buffer_apply_range(vm, source, num_source_start, num_source_end,
+                                 njs_is_defined(source_end), 0, "source",
                                  &src, &src_end);
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
@@ -2022,10 +2066,10 @@ njs_buffer_prototype_copy(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 {
     size_t              size;
     uint8_t             *src, *src_end, *trg, *trg_end;
+    uint64_t            num_target_start, num_source_start, num_source_end;
     njs_int_t           ret;
-    njs_value_t         *val1, *val2;
+    njs_value_t         *val1, *val2, *source_end_arg;
     njs_typed_array_t   *source, *target;
-    njs_array_buffer_t  *buffer;
 
     val1 = njs_argument(args, 0);
     val2 = njs_arg(args, nargs, 1);
@@ -2040,23 +2084,41 @@ njs_buffer_prototype_copy(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         return NJS_ERROR;
     }
 
-    ret = njs_buffer_array_range(vm, target, njs_arg(args, nargs, 2),
-                                 &njs_value_undefined, "target", &trg,
-                                 &trg_end);
+    num_target_start = 0;
+
+    ret = njs_buffer_range_index(vm, njs_arg(args, nargs, 2),
+                                 &num_target_start);
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
 
-    ret = njs_buffer_array_range(vm, source, njs_arg(args, nargs, 3),
-                                 njs_arg(args, nargs, 4), "source", &src,
-                                 &src_end);
+    num_source_start = 0;
+    num_source_end = 0;
+
+    ret = njs_buffer_range_index(vm, njs_arg(args, nargs, 3),
+                                 &num_source_start);
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
 
-    buffer = njs_typed_array_writable(vm, target);
-    if (njs_slow_path(buffer == NULL)) {
-        return NJS_ERROR;
+    source_end_arg = njs_arg(args, nargs, 4);
+
+    ret = njs_buffer_range_index(vm, source_end_arg, &num_source_end);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    ret = njs_buffer_apply_range(vm, target, num_target_start, 0, 0, 1,
+                                 "target", &trg, &trg_end);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    ret = njs_buffer_apply_range(vm, source, num_source_start, num_source_end,
+                                 njs_is_defined(source_end_arg), 0, "source",
+                                 &src, &src_end);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
     }
 
     size = njs_min(trg_end - trg, src_end - src);

--- a/src/qjs_buffer.c
+++ b/src/qjs_buffer.c
@@ -731,33 +731,38 @@ qjs_buffer_is_encoding(JSContext *ctx, JSValueConst this_val,
 
 
 static JSValue
-qjs_buffer_array_range(JSContext *ctx, njs_str_t *array, JSValueConst start,
-    JSValueConst end, const char *name)
+qjs_buffer_range_index(JSContext *ctx, JSValueConst value, int64_t *out)
 {
-    int64_t  num_start, num_end;
-
-    num_start = 0;
-
-    if (!JS_IsUndefined(start)) {
-        if (JS_ToInt64(ctx, &num_start, start)) {
+    if (!JS_IsUndefined(value)) {
+        if (JS_ToInt64(ctx, out, value)) {
             return JS_EXCEPTION;
         }
     }
 
+    return JS_UNDEFINED;
+}
+
+
+/*
+ * Applies an already-resolved [num_start, num_end) range to array, which
+ * must have been fetched after any JS_To*() coercion of the range bounds,
+ * so that a user callback triggered by that coercion cannot detach the
+ * buffer behind array's back.  num_end == -1 means "unset" (array->length).
+ */
+
+static JSValue
+qjs_buffer_apply_range(JSContext *ctx, njs_str_t *array, int64_t num_start,
+    int64_t num_end, const char *name)
+{
     if (num_start < 0 || (size_t) num_start > array->length) {
         return JS_ThrowRangeError(ctx, "\"%sStart\" is out of range: %" PRId64,
                                   name, num_start);
     }
 
-    num_end = array->length;
+    if (num_end == -1) {
+        num_end = array->length;
 
-    if (!JS_IsUndefined(end)) {
-        if (JS_ToInt64(ctx, &num_end, end)) {
-            return JS_EXCEPTION;
-        }
-    }
-
-    if (num_end < 0 || (size_t) num_end > array->length) {
+    } else if (num_end < 0 || (size_t) num_end > array->length) {
         return JS_ThrowRangeError(ctx, "\"%sEnd\" is out of range: %" PRId64,
                                   name, num_end);
     }
@@ -781,7 +786,34 @@ qjs_buffer_compare_array(JSContext *ctx, JSValue val1, JSValue val2,
     int        rc;
     size_t     size;
     JSValue    ret;
+    int64_t    num_target_start, num_target_end, num_source_start,
+               num_source_end;
     njs_str_t  src, target;
+
+    num_target_start = 0;
+    num_target_end = -1;
+    num_source_start = 0;
+    num_source_end = -1;
+
+    ret = qjs_buffer_range_index(ctx, source_start, &num_source_start);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
+
+    ret = qjs_buffer_range_index(ctx, source_end, &num_source_end);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
+
+    ret = qjs_buffer_range_index(ctx, target_start, &num_target_start);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
+
+    ret = qjs_buffer_range_index(ctx, target_end, &num_target_end);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
 
     ret = qjs_typed_array_data(ctx, val1, &src);
     if (JS_IsException(ret)) {
@@ -793,13 +825,14 @@ qjs_buffer_compare_array(JSContext *ctx, JSValue val1, JSValue val2,
         return ret;
     }
 
-    ret = qjs_buffer_array_range(ctx, &src, source_start, source_end, "source");
+    ret = qjs_buffer_apply_range(ctx, &src, num_source_start, num_source_end,
+                                 "source");
     if (JS_IsException(ret)) {
         return ret;
     }
 
-    ret = qjs_buffer_array_range(ctx, &target, target_start, target_end,
-                                 "target");
+    ret = qjs_buffer_apply_range(ctx, &target, num_target_start,
+                                 num_target_end, "target");
     if (JS_IsException(ret)) {
         return ret;
     }
@@ -838,7 +871,27 @@ qjs_buffer_prototype_copy(JSContext *ctx, JSValueConst this_val, int argc,
 {
     size_t     size;
     JSValue    ret;
+    int64_t    num_target_start, num_source_start, num_source_end;
     njs_str_t  src, target;
+
+    num_target_start = 0;
+    num_source_start = 0;
+    num_source_end = -1;
+
+    ret = qjs_buffer_range_index(ctx, argv[1], &num_target_start);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
+
+    ret = qjs_buffer_range_index(ctx, argv[2], &num_source_start);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
+
+    ret = qjs_buffer_range_index(ctx, argv[3], &num_source_end);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
 
     ret = qjs_typed_array_data(ctx, this_val, &src);
     if (JS_IsException(ret)) {
@@ -850,12 +903,13 @@ qjs_buffer_prototype_copy(JSContext *ctx, JSValueConst this_val, int argc,
         return ret;
     }
 
-    ret = qjs_buffer_array_range(ctx, &target, argv[1], JS_UNDEFINED, "target");
+    ret = qjs_buffer_apply_range(ctx, &target, num_target_start, -1, "target");
     if (JS_IsException(ret)) {
         return ret;
     }
 
-    ret = qjs_buffer_array_range(ctx, &src, argv[2], argv[3], "source");
+    ret = qjs_buffer_apply_range(ctx, &src, num_source_start, num_source_end,
+                                 "source");
     if (JS_IsException(ret)) {
         return ret;
     }
@@ -962,29 +1016,14 @@ qjs_buffer_prototype_index_of(JSContext *ctx, JSValueConst this_val, int argc,
     JSValueConst *argv, int last)
 {
     JSValue                      ret, buffer, encode, value;
+    njs_bool_t                   has_from;
     int64_t                      from, to, increment, length, i;
     uint32_t                     byte;
     njs_str_t                    self, str;
     const qjs_buffer_encoding_t  *encoding;
 
-    ret = qjs_typed_array_data(ctx, this_val, &self);
-    if (JS_IsException(ret)) {
-        return ret;
-    }
-
-    length = self.length;
-
-    if (last) {
-        from = length - 1;
-        to = -1;
-        increment = -1;
-
-    } else {
-        from = 0;
-        to = length;
-        increment = 1;
-    }
-
+    has_from = 0;
+    from = 0;
     encode = argv[2];
 
     if (!JS_IsUndefined(argv[1])) {
@@ -997,6 +1036,41 @@ qjs_buffer_prototype_index_of(JSContext *ctx, JSValueConst this_val, int argc,
             return JS_EXCEPTION;
         }
 
+        has_from = 1;
+    }
+
+    if (JS_IsNumber(argv[0])) {
+        if (JS_ToUint32(ctx, &byte, argv[0])) {
+            return JS_EXCEPTION;
+        }
+    }
+
+encoding:
+
+    /*
+     * Buffer data is fetched only here, after every argument coercion
+     * above that may run user code (valueOf) and detach it.
+     */
+
+    ret = qjs_typed_array_data(ctx, this_val, &self);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
+
+    length = self.length;
+
+    if (last) {
+        to = -1;
+        increment = -1;
+        from = has_from ? from : length - 1;
+
+    } else {
+        to = length;
+        increment = 1;
+        from = has_from ? from : 0;
+    }
+
+    if (has_from) {
         if (from >= 0) {
             from = njs_min(from, length);
 
@@ -1006,10 +1080,6 @@ qjs_buffer_prototype_index_of(JSContext *ctx, JSValueConst this_val, int argc,
     }
 
     if (JS_IsNumber(argv[0])) {
-        if (JS_ToUint32(ctx, &byte, argv[0])) {
-            return JS_EXCEPTION;
-        }
-
         if (last) {
             from = njs_min(from, length - 1);
         }
@@ -1022,8 +1092,6 @@ qjs_buffer_prototype_index_of(JSContext *ctx, JSValueConst this_val, int argc,
 
         return JS_NewInt32(ctx, -1);
     }
-
-encoding:
 
     buffer = JS_UNDEFINED;
     value = argv[0];
@@ -1096,16 +1164,16 @@ qjs_buffer_prototype_read_float(JSContext *ctx, JSValueConst this_val,
     njs_conv_f32_t  conv_f32;
     njs_conv_f64_t  conv_f64;
 
-    ret = qjs_typed_array_data(ctx, this_val, &self);
-    if (JS_IsException(ret)) {
-        return ret;
-    }
-
     if (JS_ToIndex(ctx, &index, argv[0])) {
         return JS_EXCEPTION;
     }
 
     size = magic >> 2;
+
+    ret = qjs_typed_array_data(ctx, this_val, &self);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
 
     if (size + index > self.length) {
         return JS_ThrowRangeError(ctx, "index %" PRIu64 " is outside the bound"
@@ -1158,11 +1226,6 @@ qjs_buffer_prototype_read_int(JSContext *ctx, JSValueConst this_val,
     njs_str_t   self;
     njs_bool_t  little, swap, sign;
 
-    ret = qjs_typed_array_data(ctx, this_val, &self);
-    if (JS_IsException(ret)) {
-        return ret;
-    }
-
     if (JS_ToIndex(ctx, &index, argv[0])) {
         return JS_EXCEPTION;
     }
@@ -1182,6 +1245,11 @@ qjs_buffer_prototype_read_int(JSContext *ctx, JSValueConst this_val,
             return JS_ThrowRangeError(ctx,
                                       "\"byteLength\" must be >= 1 and <= 6");
         }
+    }
+
+    ret = qjs_typed_array_data(ctx, this_val, &self);
+    if (JS_IsException(ret)) {
+        return ret;
     }
 
     if (size + index > self.length) {
@@ -1421,25 +1489,19 @@ qjs_buffer_prototype_to_string(JSContext *ctx, JSValueConst this_val,
     int argc, JSValueConst *argv)
 {
     uint64_t                     start, end;
+    njs_bool_t                   has_end;
     JSValue                      ret;
     njs_str_t                    src, data;
     const qjs_buffer_encoding_t  *encoding;
 
-    ret = qjs_typed_array_data(ctx, this_val, &src);
-    if (JS_IsException(ret)) {
-        return JS_ThrowTypeError(ctx, "method toString() called on incompatible"
-                                 " object");
-    }
-
     start = 0;
-    end = src.length;
+    end = 0;
+    has_end = 0;
 
     if (!JS_IsUndefined(argv[1])) {
         if (JS_ToIndex(ctx, &start, argv[1])) {
             return JS_EXCEPTION;
         }
-
-        start = njs_min(start, src.length);
     }
 
     if (!JS_IsUndefined(argv[2])) {
@@ -1447,8 +1509,17 @@ qjs_buffer_prototype_to_string(JSContext *ctx, JSValueConst this_val,
             return JS_EXCEPTION;
         }
 
-        end = njs_min(end, src.length);
+        has_end = 1;
     }
+
+    ret = qjs_typed_array_data(ctx, this_val, &src);
+    if (JS_IsException(ret)) {
+        return JS_ThrowTypeError(ctx, "method toString() called on incompatible"
+                                 " object");
+    }
+
+    start = njs_min(start, src.length);
+    end = has_end ? njs_min(end, src.length) : src.length;
 
     if (start >= end) {
         src.length = 0;
@@ -1497,18 +1568,15 @@ qjs_buffer_prototype_write(JSContext *ctx, JSValueConst this_val,
     int argc, JSValueConst *argv)
 {
     JSValue                      ret, buffer, encode;
+    njs_bool_t                   has_max_length;
     uint64_t                     offset, max_length;
     njs_str_t                    self, src;
     const uint8_t                *p, *end, *prev;
     const qjs_buffer_encoding_t  *encoding;
 
-    ret = qjs_typed_array_data(ctx, this_val, &self);
-    if (JS_IsException(ret)) {
-        return ret;
-    }
-
     offset = 0;
-    max_length = self.length;
+    max_length = 0;
+    has_max_length = 0;
     encode = argv[3];
 
     if (!JS_IsUndefined(argv[1])) {
@@ -1520,8 +1588,6 @@ qjs_buffer_prototype_write(JSContext *ctx, JSValueConst this_val,
         if (JS_ToIndex(ctx, &offset, argv[1])) {
             return JS_EXCEPTION;
         }
-
-        max_length = self.length - offset;
     }
 
     if (!JS_IsUndefined(argv[2])) {
@@ -1533,6 +1599,8 @@ qjs_buffer_prototype_write(JSContext *ctx, JSValueConst this_val,
         if (JS_ToIndex(ctx, &max_length, argv[2])) {
             return JS_EXCEPTION;
         }
+
+        has_max_length = 1;
     }
 
 write:
@@ -1548,6 +1616,16 @@ write:
     }
 
     (void) qjs_typed_array_data(ctx, buffer, &src);
+
+    ret = qjs_typed_array_data(ctx, this_val, &self);
+    if (JS_IsException(ret)) {
+        JS_FreeValue(ctx, buffer);
+        return ret;
+    }
+
+    if (!has_max_length) {
+        max_length = (offset <= self.length) ? self.length - offset : 0;
+    }
 
     if (offset > self.length) {
         JS_FreeValue(ctx, buffer);
@@ -1600,11 +1678,6 @@ qjs_buffer_prototype_write_int(JSContext *ctx, JSValueConst this_val,
     njs_str_t   self;
     njs_bool_t  little, swap, sign;
 
-    ret = qjs_typed_array_data(ctx, this_val, &self);
-    if (JS_IsException(ret)) {
-        return ret;
-    }
-
     if (JS_ToIndex(ctx, &index, argv[1])) {
         return JS_EXCEPTION;
     }
@@ -1622,6 +1695,15 @@ qjs_buffer_prototype_write_int(JSContext *ctx, JSValueConst this_val,
         }
     }
 
+    if (JS_ToInt64(ctx, &i64, argv[0])) {
+        return JS_EXCEPTION;
+    }
+
+    ret = qjs_typed_array_data(ctx, this_val, &self);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
+
     if (size + index > self.length) {
         return JS_ThrowRangeError(ctx, "index %" PRIu64 " is outside the bound"
                                   " of the buffer", index);
@@ -1634,10 +1716,6 @@ qjs_buffer_prototype_write_int(JSContext *ctx, JSValueConst this_val,
 #if NJS_HAVE_LITTLE_ENDIAN
     swap = !swap;
 #endif
-
-    if (JS_ToInt64(ctx, &i64, argv[0])) {
-        return JS_EXCEPTION;
-    }
 
     switch (size) {
     case 1:
@@ -1813,11 +1891,6 @@ qjs_buffer_prototype_write_float(JSContext *ctx, JSValueConst this_val,
     njs_conv_f32_t  conv_f32;
     njs_conv_f64_t  conv_f64;
 
-    ret = qjs_typed_array_data(ctx, this_val, &self);
-    if (JS_IsException(ret)) {
-        return ret;
-    }
-
     if (JS_ToFloat64(ctx, &v, argv[0])) {
         return JS_EXCEPTION;
     }
@@ -1827,6 +1900,11 @@ qjs_buffer_prototype_write_float(JSContext *ctx, JSValueConst this_val,
     }
 
     size = magic >> 2;
+
+    ret = qjs_typed_array_data(ctx, this_val, &self);
+    if (JS_IsException(ret)) {
+        return ret;
+    }
 
     if (size + index > self.length) {
         return JS_ThrowRangeError(ctx, "index %" PRIu64 " is outside the bound"

--- a/test/buffer.t.js
+++ b/test/buffer.t.js
@@ -151,6 +151,88 @@ let concatRevalidate_tsuite = {
 };
 
 
+let detachDuringCoercion_tsuite = {
+    name: "buf methods detach-during-argument-coercion tests",
+    skip: () => (!has_buffer() || !is_detach_available()),
+    T: async (params) => {
+        try {
+            params.run();
+
+        } catch (e) {
+            if (e.toString().startsWith('TypeError:')) {
+                return 'SUCCESS';
+            }
+
+            throw e;
+        }
+
+        throw Error(`${params.name}() did not revalidate the buffer detached`
+                    + ` during argument coercion`);
+    },
+
+    tests: [
+        { name: 'readUInt32LE', run: () => {
+              let b = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              b.readUInt32LE(evil);
+          } },
+        { name: 'readFloatLE', run: () => {
+              let b = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              b.readFloatLE(evil);
+          } },
+        { name: 'writeUInt32LE (value)', run: () => {
+              let b = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(b.buffer); return 0x41424344; } };
+              b.writeUInt32LE(evil, 0);
+          } },
+        { name: 'writeUInt32LE (offset)', run: () => {
+              let b = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              b.writeUInt32LE(0x11223344, evil);
+          } },
+        { name: 'writeFloatLE', run: () => {
+              let b = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              b.writeFloatLE(1.5, evil);
+          } },
+        { name: 'write', run: () => {
+              let b = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              b.write('hello world', evil);
+          } },
+        { name: 'toString', run: () => {
+              let b = Buffer.alloc(16, 0x41);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              b.toString('utf8', evil);
+          } },
+        { name: 'indexOf', run: () => {
+              let b = Buffer.alloc(16, 0x41);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              b.indexOf(0x41, evil);
+          } },
+        { name: 'compare (target)', run: () => {
+              let a = Buffer.alloc(16, 0x41);
+              let b = Buffer.alloc(16, 0x42);
+              let evil = { valueOf: () => { detach(b.buffer); return 0; } };
+              a.compare(b, evil);
+          } },
+        { name: 'copy (target)', run: () => {
+              let src = Buffer.alloc(16, 0x41);
+              let dst = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(dst.buffer); return 0; } };
+              src.copy(dst, evil);
+          } },
+        { name: 'copy (source)', run: () => {
+              let src = Buffer.alloc(16, 0x41);
+              let dst = Buffer.alloc(16);
+              let evil = { valueOf: () => { detach(src.buffer); return 0; } };
+              src.copy(dst, 0, evil);
+          } },
+    ],
+};
+
+
 let compare_tsuite = {
     name: "Buffer.compare() tests",
     skip: () => (!has_buffer()),
@@ -1125,6 +1207,7 @@ run([
     byteLength_tsuite,
     concat_tsuite,
     concatRevalidate_tsuite,
+    detachDuringCoercion_tsuite,
     compare_tsuite,
     comparePrototype_tsuite,
     copy_tsuite,


### PR DESCRIPTION
### Proposed changes

Several Buffer.prototype methods, in both engines, fetch the underlying ArrayBuffer's raw data pointer before finishing the coercion of their own offset/length/value arguments. In QuickJS (qjs_buffer.c) this affects the read/write integer and float accessors, write(), copy(), compare(), indexOf(), and toString(); in njs (njs_buffer.c) it affects the shared range helper behind compare()/equals() and the source side of copy(). Any of those arguments can be an object with a valueOf, and the callback it triggers can detach the very buffer whose pointer was already captured, via ArrayBuffer.prototype.transfer() or, in a test context, $262.detachArrayBuffer(). The subsequent bounds check and memory access then run against that stale pointer: a straightforward heap-use-after-free in QuickJS, since transfer() frees the backing store, and a read through a NULL-based address in njs, since its own detach only clears the data pointer. Both are reachable from ordinary script, for example `buf.compare(other, {valueOf(){other.buffer.transfer(); return 0}})`. I found the QuickJS side first, and since njs's own read/write-int functions already re-fetch the buffer after coercion, went looking for the same gap in njs's remaining Buffer methods and found it in the compare/copy range helper too. The fix in both files is the same: resolve every user-controllable argument first, and only look up the buffer pointer immediately before the bounds check and the actual read or write, so a detach mid-conversion now surfaces as the ordinary "detached buffer" error instead of touching freed or invalid memory. I added a regression suite to buffer.t.js that detaches the buffer from inside a valueOf during each affected call and asserts a TypeError is thrown.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
