### PR TITLE
Fetch: validating headers in Headers.set()

### DIFF
--- a/nginx/ngx_js_fetch.c
+++ b/nginx/ngx_js_fetch.c
@@ -2073,6 +2073,23 @@ ngx_headers_js_ext_set(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         return NJS_ERROR;
     }
 
+    ngx_js_http_trim_ows(&value.start, &value.length);
+
+    if (ngx_js_check_header_name(name.start, name.length) != NGX_OK) {
+        njs_vm_type_error(vm, "invalid header name");
+        return NJS_ERROR;
+    }
+
+    if (ngx_js_check_header_value(value.start, value.length) != NGX_OK) {
+        njs_vm_type_error(vm, "invalid header value");
+        return NJS_ERROR;
+    }
+
+    if (headers->guard == GUARD_IMMUTABLE) {
+        njs_vm_type_error(vm, "cannot append to immutable object");
+        return NJS_ERROR;
+    }
+
     part = &headers->header_list.part;
     h = part->elts;
 

--- a/nginx/ngx_qjs_fetch.c
+++ b/nginx/ngx_qjs_fetch.c
@@ -1991,6 +1991,23 @@ ngx_qjs_ext_fetch_headers_set(JSContext *cx, JSValueConst this_val,
         return JS_EXCEPTION;
     }
 
+    ngx_js_http_trim_ows(&value.data, &value.len);
+
+    if (ngx_js_check_header_name(name.data, name.len) != NGX_OK) {
+        JS_FreeCString(cx, (const char *) name.data);
+        return JS_ThrowTypeError(cx, "invalid header name");
+    }
+
+    if (ngx_js_check_header_value(value.data, value.len) != NGX_OK) {
+        JS_FreeCString(cx, (const char *) name.data);
+        return JS_ThrowTypeError(cx, "invalid header value");
+    }
+
+    if (headers->guard == GUARD_IMMUTABLE) {
+        JS_FreeCString(cx, (const char *) name.data);
+        return JS_ThrowTypeError(cx, "cannot append to immutable object");
+    }
+
     part = &headers->header_list.part;
     h = part->elts;
 


### PR DESCRIPTION
### Proposed changes

`Headers.set()` validates its arguments only when the header does not already
exist. In that case it falls through to `ngx_js_headers_append()`, which trims
optional whitespace and then checks the name with `ngx_js_check_header_name()`,
the value with `ngx_js_check_header_value()`, and the immutable guard.

When the header is already present, `set()` takes a different path: it finds the
existing entry, overwrites `h[i].value` in place and unlinks the duplicates, so
none of those checks run. As a result a value that `append()` rejects is
accepted by `set()`:

```js
var h = new Headers();
h.append('X-A', 'good');
h.append('X-B', 'a\r\nInjected: 1');   // TypeError: invalid header value
h.set('X-A', 'b\r\nInjected: 2');      // accepted
```

The immutable guard is skipped on the same path, so an existing header on an
immutable Headers object can be overwritten.

This moves the checks ahead of the lookup so both paths behave identically. Both
engines have the same structure and both are changed.

After the change the example above throws for `set()` as well, `set()` with an
ordinary value still works, and optional whitespace is trimmed as it is by
`append()`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
