### PR TITLE
HTTP: validating r.headersOut values

### DIFF
--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -10,6 +10,7 @@
 #include <ngx_core.h>
 #include <ngx_http.h>
 #include "ngx_js.h"
+#include "ngx_js_http.h"
 #include "ngx_js_modules.h"
 #include "ngx_js_form.h"
 
@@ -2548,6 +2549,11 @@ ngx_http_js_header_out_special(njs_vm_t *vm, ngx_http_request_t *r,
         return NJS_ERROR;
     }
 
+    if (ngx_js_check_header_value(s.start, s.length) != NGX_OK) {
+        njs_vm_error(vm, "invalid header value");
+        return NJS_ERROR;
+    }
+
     h = ngx_http_js_get_header(&headers->part, v->start, v->length);
 
     if (h != NULL && s.length == 0) {
@@ -2791,6 +2797,11 @@ ngx_http_js_header_generic(njs_vm_t *vm, ngx_http_request_t *r,
         }
 
         if (ngx_js_string(vm, setval, &s) != NGX_OK) {
+            return NJS_ERROR;
+        }
+
+        if (ngx_js_check_header_value(s.start, s.length) != NGX_OK) {
+            njs_vm_error(vm, "invalid header value");
             return NJS_ERROR;
         }
 
@@ -5243,6 +5254,11 @@ ngx_http_js_header_out(njs_vm_t *vm, ngx_http_request_t *r, unsigned flags,
             return NJS_ERROR;
         }
 
+        if (ngx_js_check_header_value(s.start, s.length) != NGX_OK) {
+            njs_vm_error(vm, "invalid header value");
+            return NJS_ERROR;
+        }
+
         if (s.length == 0) {
             continue;
         }
@@ -5320,6 +5336,11 @@ ngx_http_js_header_out_special(njs_vm_t *vm, ngx_http_request_t *r,
     }
 
     if (ngx_js_string(vm, setval, &s) != NGX_OK) {
+        return NJS_ERROR;
+    }
+
+    if (ngx_js_check_header_value(s.start, s.length) != NGX_OK) {
+        njs_vm_error(vm, "invalid header value");
         return NJS_ERROR;
     }
 
@@ -5595,6 +5616,11 @@ ngx_http_js_content_type(njs_vm_t *vm, ngx_http_request_t *r,
     }
 
     if (ngx_js_string(vm, setval, &s) != NGX_OK) {
+        return NJS_ERROR;
+    }
+
+    if (ngx_js_check_header_value(s.start, s.length) != NGX_OK) {
+        njs_vm_error(vm, "invalid header value");
         return NJS_ERROR;
     }
 
@@ -8684,6 +8710,11 @@ ngx_http_qjs_headers_out_handler(JSContext *cx, ngx_http_request_t *r,
             return -1;
         }
 
+        if (ngx_js_check_header_value(s.data, s.len) != NGX_OK) {
+            (void) JS_ThrowTypeError(cx, "invalid header value");
+            return -1;
+        }
+
         if (s.len == 0) {
             continue;
         }
@@ -8773,6 +8804,11 @@ ngx_http_qjs_headers_out_special_handler(JSContext *cx, ngx_http_request_t *r,
     }
 
     if (rc != NGX_OK) {
+        return -1;
+    }
+
+    if (ngx_js_check_header_value(s.data, s.len) != NGX_OK) {
+        (void) JS_ThrowTypeError(cx, "invalid header value");
         return -1;
     }
 
@@ -8999,6 +9035,11 @@ ngx_http_qjs_headers_out_content_type(JSContext *cx, ngx_http_request_t *r,
     }
 
     if (rc != NGX_OK) {
+        return -1;
+    }
+
+    if (ngx_js_check_header_value(s.data, s.len) != NGX_OK) {
+        (void) JS_ThrowTypeError(cx, "invalid header value");
         return -1;
     }
 


### PR DESCRIPTION
`r.headersOut` stores values without validating them, while `ngx_js_check_header_value()` is applied only on the Fetch `Headers` path. Because njs decodes `r.args`, an ordinary handler

```js
function h(r) {
    r.headersOut['X-Test'] = r.args.v;
    r.return(200, 'ok\n');
}
```

with `/hdr?v=a%0d%0aInjected:%201` produces a genuinely split response:

```
X-Test: a
Injected: 1
```

This differs from nginx core, where `add_header X $arg_v` is safe: `$arg_` is not decoded, so a raw CR LF cannot survive request-line parsing. The decoding njs does is what makes it reachable here.

The change calls the existing helper at the points where the final value is produced, in both engines:

-- the generic path, including array values such as `Set-Cookie`
-- the special headers handled separately (`Location`, `Server`, `Content-Encoding`)
-- `Content-Type`, which has its own handler and was otherwise missed

Covering only the generic path is not enough -- `Location` and `Content-Type` remain injectable, and `Location` is the more interesting target of the two.

Checked on both engines, with `js_engine qjs` and the default: benign values still set (`X-Test`, `Location`, `Content-Type`), `Set-Cookie` arrays still produce both cookies, and all three CRLF cases are rejected with a type error, with no injected header appearing in the response.

Two questions I would rather you decide than presume.

Rejecting is a behaviour change. A configuration that currently sets a header from decoded input and happens to work will start throwing. Sanitising, or rejecting only CR and LF rather than all control characters, are both defensible alternatives.

The pre-1.23 paths under `nginx_version < 1023000` are patched by inspection, in the same places, but not exercised: the lab here builds against current nginx.

I have not touched `r.headersIn` or the guard question raised alongside this, since neither is a store path.
