### PR TITLE
Fetch: copied body bytes into ArrayBuffer

### DIFF
--- a/nginx/ngx_qjs_fetch.c
+++ b/nginx/ngx_qjs_fetch.c
@@ -1947,12 +1947,13 @@ ngx_qjs_ext_fetch_request_body(JSContext *cx, JSValueConst this_val,
     switch (magic) {
     case NGX_JS_BODY_ARRAY_BUFFER:
         /*
-         * no free_func for JS_NewArrayBuffer()
-         * because request->body is allocated from e->pool
-         * and will be freed when context is freed.
+         * The body is allocated from the engine pool, which is destroyed at
+         * the end of the request, while the context may be reused by the
+         * next one.  The bytes are copied so that the buffer does not
+         * outlive its backing store.
          */
-        result = JS_NewArrayBuffer(cx, request->body.data, request->body.len,
-                                   NULL, NULL, 0);
+        result = JS_NewArrayBufferCopy(cx, request->body.data,
+                                       request->body.len);
         if (JS_IsException(result)) {
             return JS_ThrowOutOfMemory(cx);
         }
@@ -2244,12 +2245,12 @@ ngx_qjs_ext_fetch_response_body(JSContext *cx, JSValueConst this_val,
         }
 
         /*
-         * no free_func for JS_NewArrayBuffer()
-         * because string.start is allocated from e->pool
-         * and will be freed when context is freed.
+         * The body is allocated from the engine pool, which is destroyed at
+         * the end of the request, while the context may be reused by the
+         * next one.  The bytes are copied so that the buffer does not
+         * outlive its backing store.
          */
-        result = JS_NewArrayBuffer(cx, string.start, string.length, NULL, NULL,
-                                   0);
+        result = JS_NewArrayBufferCopy(cx, string.start, string.length);
         if (JS_IsException(result)) {
             return JS_ThrowOutOfMemory(cx);
         }


### PR DESCRIPTION
`Response.arrayBuffer()` and the request body accessor create an ArrayBuffer over memory owned by the per-request engine pool, with no free callback. The comment at the allocation site states the assumption:

```
 * no free_func for JS_NewArrayBuffer()
 * because request->body is allocated from e->pool
 * and will be freed when context is freed.
```

`js_context_reuse` invalidates it. It is enabled by default, and under it the pool is destroyed at the end of the request while the `JSContext` survives and is handed to the next request -- so the pool dies first, not last.

A buffer or typed array retained in module scope therefore points into freed memory. Once the pool is reused the retained view reads whatever now occupies it, which is another request's data.

Both sites now use `JS_NewArrayBufferCopy()`, as `text()` and `json()` already do, and as `qjs_webcrypto_module.c` does. A retained view then owns its bytes and no longer depends on the engine pool outliving it.

Reproduced with a handler that caches a fetched `arrayBuffer()` in module scope, performs a second fetch so the freed pool is reallocated, and re-reads the cached view: before the change it returned unrelated engine data, which the handler then sent to the client; after it, the view returns its own bytes. Note the crash a reproduction may produce depends on allocator timing, whereas the contamination is deterministic.
