### PR TITLE
Pre js context reuse fixes hardening

### DIFF
--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -2183,10 +2183,8 @@ ngx_http_js_init_vm(ngx_http_request_t *r, njs_int_t proto_id)
 static void
 ngx_http_js_cleanup_ctx(void *data)
 {
-    ngx_http_request_t      *r;
-    ngx_http_js_loc_conf_t  *jlcf;
-
-    ngx_http_js_ctx_t        *ctx = data;
+    ngx_http_request_t  *r;
+    ngx_http_js_ctx_t   *ctx = data;
 
     if (ngx_js_ctx_pending(ctx)) {
         ngx_log_error(NGX_LOG_ERR, ctx->log, 0, "pending events");
@@ -2198,13 +2196,11 @@ ngx_http_js_cleanup_ctx(void *data)
     r = ngx_js_ctx_external(ctx);
 
     /*
-     * Restoring the original module context, because it can be reset
-     * by internalRedirect() method. Proper ctx is required for
-     * ngx_http_qjs_request_finalizer() to work correctly.
+     * Restoring the original module context, because it can be reset by
+     * internalRedirect().  Exit hooks and event destructors must resolve the
+     * context being destroyed.
      */
     ngx_http_set_ctx(r, ctx, ngx_http_js_module);
-
-    jlcf = ngx_http_get_module_loc_conf(r, ngx_http_js_module);
 
     /*
      * r->pool set to NULL by ngx_http_free_request().
@@ -2213,7 +2209,7 @@ ngx_http_js_cleanup_ctx(void *data)
      */
     r->pool = ngx_create_pool(128, ctx->log);
 
-    ngx_js_ctx_destroy((ngx_js_ctx_t *) ctx, (ngx_js_loc_conf_t *) jlcf);
+    ngx_js_ctx_destroy((ngx_js_ctx_t *) ctx);
 
     ngx_destroy_pool(r->pool);
 }

--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -494,6 +494,8 @@ static int ngx_http_qjs_headers_out_delete_property(JSContext *cx,
 static ngx_http_request_t *ngx_http_qjs_request(JSValueConst val);
 static JSValue ngx_http_qjs_request_make(JSContext *cx, ngx_int_t proto_id,
     ngx_http_request_t *r);
+static void ngx_http_qjs_request_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func);
 static void ngx_http_qjs_request_finalizer(JSRuntime *rt, JSValue val);
 static void ngx_http_qjs_periodic_finalizer(JSRuntime *rt, JSValue val);
 #endif
@@ -1469,6 +1471,7 @@ static const JSCFunctionListEntry ngx_http_qjs_ext_request_form[] = {
 static JSClassDef ngx_http_qjs_request_class = {
     "Request",
     .finalizer = ngx_http_qjs_request_finalizer,
+    .gc_mark = ngx_http_qjs_request_mark,
 };
 
 
@@ -9415,6 +9418,21 @@ ngx_http_qjs_request_make(JSContext *cx, ngx_int_t proto_id,
     JS_SetOpaque(request, req);
 
     return request;
+}
+
+
+static void
+ngx_http_qjs_request_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func)
+{
+    ngx_http_qjs_request_t  *req;
+
+    req = JS_GetOpaque(val, NGX_QJS_CLASS_ID_HTTP_REQUEST);
+    if (req != NULL) {
+        JS_MarkValue(rt, req->args, mark_func);
+        JS_MarkValue(rt, req->request_body, mark_func);
+        JS_MarkValue(rt, req->response_body, mark_func);
+    }
 }
 
 

--- a/nginx/ngx_http_js_module.c
+++ b/nginx/ngx_http_js_module.c
@@ -2132,6 +2132,7 @@ ngx_http_js_variable_var(ngx_http_request_t *r, ngx_http_variable_value_t *v,
 static ngx_int_t
 ngx_http_js_init_vm(ngx_http_request_t *r, njs_int_t proto_id)
 {
+    ngx_engine_t            *engine;
     ngx_http_js_ctx_t       *ctx;
     ngx_pool_cleanup_t      *cln;
     ngx_http_js_loc_conf_t  *jlcf;
@@ -2158,20 +2159,23 @@ ngx_http_js_init_vm(ngx_http_request_t *r, njs_int_t proto_id)
         return NGX_OK;
     }
 
-    ctx->engine = jlcf->engine->clone((ngx_js_ctx_t *) ctx,
-                                      (ngx_js_loc_conf_t *) jlcf, proto_id, r);
-    if (ctx->engine == NULL) {
+    engine = jlcf->engine->clone((ngx_js_ctx_t *) ctx,
+                                 (ngx_js_loc_conf_t *) jlcf, proto_id, r);
+    if (engine == NULL) {
         return NGX_ERROR;
     }
+
+    cln = ngx_pool_cleanup_add(r->pool, 0);
+    if (cln == NULL) {
+        ngx_js_clone_abort((ngx_js_ctx_t *) ctx, engine);
+        return NGX_ERROR;
+    }
+
+    ctx->engine = engine;
 
     ngx_log_debug3(NGX_LOG_DEBUG_HTTP, ctx->log, 0,
                    "http js vm clone %s: %p from: %p", jlcf->engine->name,
                    ctx->engine, jlcf->engine);
-
-    cln = ngx_pool_cleanup_add(r->pool, 0);
-    if (cln == NULL) {
-        return NGX_ERROR;
-    }
 
     cln->handler = ngx_http_js_cleanup_ctx;
     cln->data = ctx;
@@ -6038,6 +6042,7 @@ ngx_engine_njs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
                                 proto_id, njs_vm_external_ptr(engine->u.njs.vm),
                                 0);
     if (rc != NJS_OK) {
+        ngx_js_clone_abort(ctx, engine);
         return NULL;
     }
 
@@ -9403,6 +9408,7 @@ ngx_http_qjs_request_make(JSContext *cx, ngx_int_t proto_id,
 
     req = js_malloc(cx, sizeof(ngx_http_qjs_request_t));
     if (req == NULL) {
+        JS_FreeValue(cx, request);
         return JS_ThrowOutOfMemory(cx);
     }
 
@@ -9486,12 +9492,12 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_HTTP_REQUEST,
                         &ngx_http_qjs_request_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         proto = JS_NewObject(cx);
         if (JS_IsException(proto)) {
-            return NULL;
+            goto failed;
         }
 
         JS_SetPropertyFunctionList(cx, proto, ngx_http_qjs_ext_request,
@@ -9502,12 +9508,12 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_HTTP_FORM,
                         &ngx_http_qjs_request_form_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         proto = JS_NewObject(cx);
         if (JS_IsException(proto)) {
-            return NULL;
+            goto failed;
         }
 
         JS_SetPropertyFunctionList(cx, proto, ngx_http_qjs_ext_request_form,
@@ -9518,12 +9524,12 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_HTTP_PERIODIC,
                         &ngx_http_qjs_periodic_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         proto = JS_NewObject(cx);
         if (JS_IsException(proto)) {
-            return NULL;
+            goto failed;
         }
 
         JS_SetPropertyFunctionList(cx, proto, ngx_http_qjs_ext_periodic,
@@ -9534,24 +9540,21 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_HTTP_VARS,
                         &ngx_http_qjs_variables_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_HTTP_HEADERS_IN,
                         &ngx_http_qjs_headers_in_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_HTTP_HEADERS_OUT,
                         &ngx_http_qjs_headers_out_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
     }
-
-    hctx = (ngx_http_js_ctx_t *) ctx;
-    hctx->body_filter = ngx_http_qjs_body_filter;
 
     if (proto_id == ngx_http_js_request_proto_id) {
         proto_id = NGX_QJS_CLASS_ID_HTTP_REQUEST;
@@ -9560,13 +9563,22 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         proto_id = NGX_QJS_CLASS_ID_HTTP_PERIODIC;
     }
 
-    ngx_qjs_arg(hctx->args[0]) = ngx_http_qjs_request_make(cx, proto_id,
-                                                           external);
-    if (JS_IsException(ngx_qjs_arg(hctx->args[0]))) {
-        return NULL;
+    ngx_qjs_arg(ctx->args[0]) = ngx_http_qjs_request_make(cx, proto_id,
+                                                          external);
+    if (JS_IsException(ngx_qjs_arg(ctx->args[0]))) {
+        goto failed;
     }
 
+    hctx = (ngx_http_js_ctx_t *) ctx;
+    hctx->body_filter = ngx_http_qjs_body_filter;
+
     return engine;
+
+failed:
+
+    ngx_js_clone_abort(ctx, engine);
+
+    return NULL;
 }
 
 #endif

--- a/nginx/ngx_js.c
+++ b/nginx/ngx_js.c
@@ -1240,11 +1240,12 @@ void
 ngx_engine_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
     ngx_js_loc_conf_t *conf)
 {
+    JSValue               ret;
     uint32_t              i, length;
     JSRuntime            *rt;
-    JSValue               ret;
     JSContext            *cx;
     JSClassID             class_id;
+    ngx_uint_t            reusable;
     JSMemoryUsage         stats;
     ngx_qjs_event_t      *event;
     ngx_js_opaque_t      *opaque;
@@ -1253,6 +1254,7 @@ ngx_engine_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
     ngx_js_code_entry_t  *pc;
 
     cx = e->u.qjs.ctx;
+    reusable = 1;
 
     if (ctx != NULL) {
         ret = qjs_call_exit_hook(cx);
@@ -1260,7 +1262,9 @@ ngx_engine_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
             ngx_qjs_log_exception(e, ctx->log, "exit hook exception");
         }
 
-        (void) ngx_qjs_execute_pending_jobs(cx, ctx->log);
+        if (ngx_qjs_execute_pending_jobs(cx, ctx->log) != NGX_OK) {
+            reusable = 0;
+        }
 
         node = njs_rbtree_min(&ctx->waiting_events);
 
@@ -1288,6 +1292,13 @@ ngx_engine_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
         JS_FreeValue(cx, ngx_qjs_arg(ctx->args[0]));
         JS_FreeValue(cx, ngx_qjs_arg(ctx->retval));
 
+        if (JS_IsJobPending(JS_GetRuntime(cx))) {
+            ngx_log_error(NGX_LOG_ERR, ctx->log, 0,
+                          "js pending jobs after context teardown, "
+                          "not reusing context");
+            reusable = 0;
+        }
+
     } else if (e->precompiled != NULL) {
         pc = e->precompiled->start;
         length = e->precompiled->items;
@@ -1299,7 +1310,7 @@ ngx_engine_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
 
     njs_mp_destroy(e->pool);
 
-    if (conf != NULL && conf->reuse != 0) {
+    if (conf != NULL && conf->reuse != 0 && reusable) {
         if (conf->reuse_queue == NULL) {
             conf->reuse_queue = ngx_js_queue_create(ngx_cycle->pool,
                                                     conf->reuse);

--- a/nginx/ngx_js.c
+++ b/nginx/ngx_js.c
@@ -769,6 +769,7 @@ ngx_njs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
     memcpy(engine, cf->engine, sizeof(ngx_engine_t));
     engine->pool = njs_vm_memory_pool(vm);
     engine->u.njs.vm = vm;
+    ctx->conf = cf;
 
     if (njs_vm_start(vm, njs_value_arg(&retval)) == NJS_ERROR) {
         ngx_js_log_exception(vm, ctx->log, "exception");
@@ -1055,6 +1056,7 @@ ngx_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
 
     memcpy(engine, cf->engine, sizeof(ngx_engine_t));
     engine->pool = mp;
+    ctx->conf = cf;
 
     if (cf->reuse_queue != NULL) {
         engine->u.qjs.ctx = ngx_js_queue_pop(cf->reuse_queue);
@@ -2606,9 +2608,9 @@ ngx_js_ctx_init(ngx_js_ctx_t *ctx, ngx_log_t *log)
 
 
 void
-ngx_js_ctx_destroy(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *conf)
+ngx_js_ctx_destroy(ngx_js_ctx_t *ctx)
 {
-    ctx->engine->destroy(ctx->engine, ctx, conf);
+    ctx->engine->destroy(ctx->engine, ctx, ctx->conf);
 }
 
 

--- a/nginx/ngx_js.c
+++ b/nginx/ngx_js.c
@@ -55,10 +55,13 @@ static void *ngx_engine_njs_external(ngx_engine_t *engine);
 static ngx_int_t ngx_engine_njs_pending(ngx_engine_t *engine);
 static ngx_int_t ngx_engine_njs_string(ngx_engine_t *e,
     njs_opaque_value_t *value, ngx_str_t *str);
+static void ngx_njs_clear_events(ngx_js_ctx_t *ctx);
 static void ngx_engine_njs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
     ngx_js_loc_conf_t *conf);
 static ngx_int_t ngx_js_init_preload_vm(njs_vm_t *vm, ngx_js_loc_conf_t *conf);
 static ngx_int_t ngx_js_integer_in_range(double num);
+static intptr_t ngx_js_event_rbtree_compare(njs_rbtree_node_t *node1,
+    njs_rbtree_node_t *node2);
 
 static ngx_int_t ngx_njs_execute_pending_jobs(njs_vm_t *vm, ngx_log_t *log);
 static njs_int_t ngx_njs_await(njs_vm_t *vm, ngx_log_t *log,
@@ -78,6 +81,8 @@ static void *ngx_engine_qjs_external(ngx_engine_t *engine);
 static ngx_int_t ngx_engine_qjs_pending(ngx_engine_t *engine);
 static ngx_int_t ngx_engine_qjs_string(ngx_engine_t *e,
     njs_opaque_value_t *value, ngx_str_t *str);
+static void ngx_qjs_clear_events(ngx_js_ctx_t *ctx);
+static void ngx_qjs_detach_ctx(ngx_js_ctx_t *ctx, JSContext *cx);
 
 static JSValue ngx_qjs_process_getter(JSContext *ctx, JSValueConst this_val);
 static JSValue ngx_qjs_ext_set_timeout(JSContext *cx, JSValueConst this_val,
@@ -529,6 +534,7 @@ ngx_create_engine(ngx_engine_opts_t *opts)
 
     engine = njs_mp_zalloc(mp, sizeof(ngx_engine_t));
     if (engine == NULL) {
+        njs_mp_destroy(mp);
         return NULL;
     }
 
@@ -543,7 +549,7 @@ ngx_create_engine(ngx_engine_opts_t *opts)
     case NGX_ENGINE_NJS:
         rc = ngx_engine_njs_init(engine, opts);
         if (rc != NGX_OK) {
-            return NULL;
+            goto failed;
         }
 
         engine->name = "njs";
@@ -561,7 +567,7 @@ ngx_create_engine(ngx_engine_opts_t *opts)
     case NGX_ENGINE_QJS:
         rc = ngx_engine_qjs_init(engine, opts);
         if (rc != NGX_OK) {
-            return NULL;
+            goto failed;
         }
 
         engine->name = "QuickJS";
@@ -579,10 +585,16 @@ ngx_create_engine(ngx_engine_opts_t *opts)
 #endif
 
     default:
-        return NULL;
+        goto failed;
     }
 
     return engine;
+
+failed:
+
+    njs_mp_destroy(mp);
+
+    return NULL;
 }
 
 
@@ -773,15 +785,21 @@ ngx_njs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
 
     if (njs_vm_start(vm, njs_value_arg(&retval)) == NJS_ERROR) {
         ngx_js_log_exception(vm, ctx->log, "exception");
-        goto destroy;
+        goto failed;
     }
 
     ret = ngx_njs_await(vm, ctx->log, njs_value_arg(&retval));
     if (ret == NGX_ERROR) {
-        goto destroy;
+        goto failed;
     }
 
     return engine;
+
+failed:
+
+    ngx_js_clone_abort(ctx, engine);
+
+    return NULL;
 
 destroy:
 
@@ -859,12 +877,34 @@ ngx_engine_njs_string(ngx_engine_t *e, njs_opaque_value_t *value,
 
 
 static void
+ngx_njs_clear_events(ngx_js_ctx_t *ctx)
+{
+    ngx_js_event_t     *event;
+    njs_rbtree_node_t  *node;
+
+    node = njs_rbtree_min(&ctx->waiting_events);
+
+    while (njs_rbtree_is_there_successor(&ctx->waiting_events, node)) {
+        event = (ngx_js_event_t *) ((u_char *) node
+                                    - offsetof(ngx_js_event_t, node));
+
+        if (event->destructor != NULL) {
+            event->destructor(event);
+        }
+
+        node = njs_rbtree_node_successor(&ctx->waiting_events, node);
+    }
+
+    ctx->event_id = 0;
+    njs_rbtree_init(&ctx->waiting_events, ngx_js_event_rbtree_compare);
+}
+
+
+static void
 ngx_engine_njs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
     ngx_js_loc_conf_t *conf)
 {
-    njs_int_t           ret;
-    ngx_js_event_t     *event;
-    njs_rbtree_node_t  *node;
+    njs_int_t  ret;
 
     if (ctx != NULL) {
         ret = njs_vm_call_exit_hook(e->u.njs.vm);
@@ -874,18 +914,7 @@ ngx_engine_njs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
 
         (void) ngx_njs_execute_pending_jobs(e->u.njs.vm, ctx->log);
 
-        node = njs_rbtree_min(&ctx->waiting_events);
-
-        while (njs_rbtree_is_there_successor(&ctx->waiting_events, node)) {
-            event = (ngx_js_event_t *) ((u_char *) node
-                                        - offsetof(ngx_js_event_t, node));
-
-            if (event->destructor != NULL) {
-                event->destructor(event);
-            }
-
-            node = njs_rbtree_node_successor(&ctx->waiting_events, node);
-        }
+        ngx_njs_clear_events(ctx);
 
         if (ngx_js_unhandled_rejection(ctx)) {
             ngx_js_log_exception(e->u.njs.vm, ctx->log, "unhandled rejection");
@@ -902,6 +931,40 @@ ngx_engine_njs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
     if (ctx == NULL) {
         njs_mp_destroy(e->pool);
     }
+}
+
+
+void
+ngx_js_clone_abort(ngx_js_ctx_t *ctx, ngx_engine_t *engine)
+{
+    /* The clone must not be published in ctx->engine before this call. */
+
+    if (engine->type == NGX_ENGINE_NJS) {
+        ngx_njs_clear_events(ctx);
+        ctx->rejected_promises = NULL;
+        njs_vm_destroy(engine->u.njs.vm);
+        return;
+    }
+
+#if (NJS_HAVE_QUICKJS)
+    JSRuntime  *rt;
+    JSContext  *cx;
+
+    ngx_qjs_clear_events(ctx);
+    cx = engine->u.qjs.ctx;
+
+    if (cx != NULL) {
+        rt = JS_GetRuntime(cx);
+
+        JS_SetHostPromiseRejectionTracker(rt, NULL, NULL);
+        ngx_qjs_detach_ctx(ctx, cx);
+
+        JS_FreeContext(cx);
+        JS_FreeRuntime(rt);
+    }
+
+    njs_mp_destroy(engine->pool);
+#endif
 }
 
 
@@ -979,6 +1042,7 @@ ngx_engine_qjs_init(ngx_engine_t *engine, ngx_engine_opts_t *opts)
 
     engine->u.qjs.ctx = qjs_new_context(rt, opts->u.qjs.addons);
     if (engine->u.qjs.ctx == NULL) {
+        JS_FreeRuntime(rt);
         return NGX_ERROR;
     }
 
@@ -1051,11 +1115,13 @@ ngx_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
 
     engine = njs_mp_alloc(mp, sizeof(ngx_engine_t));
     if (engine == NULL) {
+        njs_mp_destroy(mp);
         return NULL;
     }
 
     memcpy(engine, cf->engine, sizeof(ngx_engine_t));
     engine->pool = mp;
+    engine->u.qjs.ctx = NULL;
     ctx->conf = cf;
 
     if (cf->reuse_queue != NULL) {
@@ -1074,7 +1140,7 @@ ngx_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
 
     rt = JS_NewRuntime();
     if (rt == NULL) {
-        return NULL;
+        goto failed;
     }
 
     JS_SetRuntimeOpaque(rt, JS_GetRuntimeOpaque(
@@ -1083,7 +1149,7 @@ ngx_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
     cx = qjs_new_context(rt, JS_GetContextOpaque(cf->engine->u.qjs.ctx));
     if (cx == NULL) {
         JS_FreeRuntime(rt);
-        return NULL;
+        goto failed;
     }
 
     engine->u.qjs.ctx = cx;
@@ -1099,7 +1165,7 @@ ngx_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
             if (mod[i].init(cx, mod[i].name) == NULL) {
                 ngx_log_error(NGX_LOG_ERR, ctx->log, 0,
                               "js native module init failed: %s", mod[i].name);
-                goto destroy;
+                goto failed;
             }
         }
     }
@@ -1113,7 +1179,7 @@ ngx_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
                            JS_READ_OBJ_BYTECODE);
         if (JS_IsException(rv)) {
             ngx_qjs_log_exception(engine, ctx->log, "load module exception");
-            goto destroy;
+            goto failed;
         }
 
         if (i != length - 1) {
@@ -1124,30 +1190,29 @@ ngx_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf, void *external)
 
     if (JS_ResolveModule(cx, rv) < 0) {
         ngx_log_error(NGX_LOG_ERR, ctx->log, 0, "js resolve module failed");
-        goto destroy;
+        JS_FreeValue(cx, rv);
+        goto failed;
     }
 
     rv = JS_EvalFunction(cx, rv);
 
     if (JS_IsException(rv)) {
         ngx_qjs_log_exception(engine, ctx->log, "eval exception");
-        goto destroy;
+        goto failed;
     }
 
     rc = ngx_qjs_await(cx, ctx->log, &rv);
     JS_FreeValue(cx, rv);
     if (rc == NGX_ERROR) {
         ngx_qjs_log_exception(engine, ctx->log, "await exception");
-        goto destroy;
+        goto failed;
     }
 
     return engine;
 
-destroy:
+failed:
 
-    JS_FreeContext(cx);
-    JS_FreeRuntime(rt);
-    njs_mp_destroy(mp);
+    ngx_js_clone_abort(ctx, engine);
 
     return NULL;
 }
@@ -1216,6 +1281,55 @@ ngx_engine_qjs_string(ngx_engine_t *e, njs_opaque_value_t *value,
 
 
 static void
+ngx_qjs_detach_ctx(ngx_js_ctx_t *ctx, JSContext *cx)
+{
+    JSClassID        class_id;
+    ngx_js_opaque_t  *opaque;
+
+    if (JS_IsObject(ngx_qjs_arg(ctx->args[0]))) {
+        class_id = JS_GetClassID(ngx_qjs_arg(ctx->args[0]));
+        opaque = JS_GetOpaque(ngx_qjs_arg(ctx->args[0]), class_id);
+
+        if (opaque != NULL) {
+            opaque->external = NULL;
+        }
+    }
+
+    JS_FreeValue(cx, ngx_qjs_arg(ctx->args[0]));
+    JS_FreeValue(cx, ngx_qjs_arg(ctx->retval));
+
+    ngx_qjs_arg(ctx->args[0]) = JS_UNDEFINED;
+    ngx_qjs_arg(ctx->retval) = JS_UNDEFINED;
+
+    JS_SetContextOpaque(cx, NULL);
+}
+
+
+static void
+ngx_qjs_clear_events(ngx_js_ctx_t *ctx)
+{
+    ngx_qjs_event_t    *event;
+    njs_rbtree_node_t  *node;
+
+    node = njs_rbtree_min(&ctx->waiting_events);
+
+    while (njs_rbtree_is_there_successor(&ctx->waiting_events, node)) {
+        event = (ngx_qjs_event_t *) ((u_char *) node
+                                     - offsetof(ngx_qjs_event_t, node));
+
+        if (event->destructor != NULL) {
+            event->destructor(event);
+        }
+
+        node = njs_rbtree_node_successor(&ctx->waiting_events, node);
+    }
+
+    ctx->event_id = 0;
+    njs_rbtree_init(&ctx->waiting_events, ngx_js_event_rbtree_compare);
+}
+
+
+static void
 ngx_js_cleanup_reuse_ctx(void *data)
 {
     JSRuntime  *rt;
@@ -1244,12 +1358,8 @@ ngx_engine_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
     uint32_t              i, length;
     JSRuntime            *rt;
     JSContext            *cx;
-    JSClassID             class_id;
     ngx_uint_t            reusable;
     JSMemoryUsage         stats;
-    ngx_qjs_event_t      *event;
-    ngx_js_opaque_t      *opaque;
-    njs_rbtree_node_t    *node;
     ngx_pool_cleanup_t   *cln;
     ngx_js_code_entry_t  *pc;
 
@@ -1266,31 +1376,14 @@ ngx_engine_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
             reusable = 0;
         }
 
-        node = njs_rbtree_min(&ctx->waiting_events);
-
-        while (njs_rbtree_is_there_successor(&ctx->waiting_events, node)) {
-            event = (ngx_qjs_event_t *) ((u_char *) node
-                                         - offsetof(ngx_qjs_event_t, node));
-
-            if (event->destructor != NULL) {
-                event->destructor(event);
-            }
-
-            node = njs_rbtree_node_successor(&ctx->waiting_events, node);
-        }
+        ngx_qjs_clear_events(ctx);
 
         if (ngx_qjs_unhandled_rejection(ctx)) {
             ngx_qjs_log_exception(e, ctx->log, "unhandled rejection");
         }
 
         JS_SetHostPromiseRejectionTracker(JS_GetRuntime(cx), NULL, NULL);
-
-        class_id = JS_GetClassID(ngx_qjs_arg(ctx->args[0]));
-        opaque = JS_GetOpaque(ngx_qjs_arg(ctx->args[0]), class_id);
-        opaque->external = NULL;
-
-        JS_FreeValue(cx, ngx_qjs_arg(ctx->args[0]));
-        JS_FreeValue(cx, ngx_qjs_arg(ctx->retval));
+        ngx_qjs_detach_ctx(ctx, cx);
 
         if (JS_IsJobPending(JS_GetRuntime(cx))) {
             ngx_log_error(NGX_LOG_ERR, ctx->log, 0,

--- a/nginx/ngx_js.h
+++ b/nginx/ngx_js.h
@@ -189,6 +189,7 @@ typedef struct {
 
 #define NGX_JS_COMMON_CTX                                                     \
     ngx_engine_t          *engine;                                            \
+    ngx_js_loc_conf_t     *conf;                                              \
     ngx_log_t             *log;                                               \
     njs_opaque_value_t     args[3];                                           \
     njs_opaque_value_t     retval;                                            \
@@ -357,7 +358,7 @@ void ngx_js_ctx_init(ngx_js_ctx_t *ctx, ngx_log_t *log);
     ((ctx)->engine->external(ctx->engine))
 
 
-void ngx_js_ctx_destroy(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *conf);
+void ngx_js_ctx_destroy(ngx_js_ctx_t *ctx);
 ngx_int_t ngx_js_call(njs_vm_t *vm, njs_function_t *func,
     njs_opaque_value_t *args, njs_uint_t nargs);
 ngx_int_t ngx_js_log_exception(njs_vm_t *vm, ngx_log_t *log, const char *txt);

--- a/nginx/ngx_js.h
+++ b/nginx/ngx_js.h
@@ -364,6 +364,7 @@ ngx_int_t ngx_js_call(njs_vm_t *vm, njs_function_t *func,
 ngx_int_t ngx_js_log_exception(njs_vm_t *vm, ngx_log_t *log, const char *txt);
 ngx_engine_t *ngx_njs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
     void *external);
+void ngx_js_clone_abort(ngx_js_ctx_t *ctx, ngx_engine_t *engine);
 
 #define NGX_CHB_CTX_INIT(chain, pool)                                        \
     njs_chb_init(chain, pool, (njs_chb_alloc_t) ngx_palloc, NULL)

--- a/nginx/ngx_qjs_fetch.c
+++ b/nginx/ngx_qjs_fetch.c
@@ -28,6 +28,12 @@ typedef struct {
 } ngx_qjs_fetch_t;
 
 
+typedef struct {
+    void      *data;
+    JSValue    header_value;
+} ngx_qjs_fetch_object_t;
+
+
 static ngx_int_t ngx_qjs_method_process(JSContext *cx,
     ngx_js_request_t *request);
 static ngx_int_t ngx_qjs_headers_inherit(JSContext *cx,
@@ -89,6 +95,8 @@ static JSValue ngx_qjs_ext_fetch_request_field(JSContext *cx,
     JSValueConst this_val, int magic);
 static JSValue ngx_qjs_ext_fetch_request_mode(JSContext *cx,
     JSValueConst this_val);
+static void ngx_qjs_fetch_request_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func);
 static void ngx_qjs_fetch_request_finalizer(JSRuntime *rt, JSValue val);
 
 static JSValue ngx_qjs_fetch_response_ctor(JSContext *cx,
@@ -111,6 +119,8 @@ static JSValue ngx_qjs_ext_fetch_response_redirected(JSContext *cx,
     JSValueConst this_val);
 static JSValue ngx_qjs_ext_fetch_response_field(JSContext *cx,
     JSValueConst this_val, int magic);
+static void ngx_qjs_fetch_response_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func);
 static void ngx_qjs_fetch_response_finalizer(JSRuntime *rt, JSValue val);
 
 static JSValue ngx_qjs_fetch_flag(JSContext *cx, const ngx_qjs_entry_t *entries,
@@ -183,12 +193,14 @@ static const JSClassDef  ngx_qjs_fetch_headers_class = {
 static const JSClassDef  ngx_qjs_fetch_request_class = {
     "Request",
     .finalizer = ngx_qjs_fetch_request_finalizer,
+    .gc_mark = ngx_qjs_fetch_request_mark,
 };
 
 
 static const JSClassDef  ngx_qjs_fetch_response_class = {
     "Response",
     .finalizer = ngx_qjs_fetch_response_finalizer,
+    .gc_mark = ngx_qjs_fetch_response_mark,
 };
 
 
@@ -477,6 +489,37 @@ ngx_qjs_fetch_headers_ctor(JSContext *cx, JSValueConst new_target, int argc,
 }
 
 
+static ngx_int_t
+ngx_qjs_fetch_object_set(JSContext *cx, JSValueConst value, void *data)
+{
+    ngx_qjs_fetch_object_t  *object;
+
+    object = js_malloc(cx, sizeof(ngx_qjs_fetch_object_t));
+    if (object == NULL) {
+        return NGX_ERROR;
+    }
+
+    object->data = data;
+    object->header_value = JS_UNDEFINED;
+
+    JS_SetOpaque(value, object);
+
+    return NGX_OK;
+}
+
+
+static void *
+ngx_qjs_fetch_object_data(JSContext *cx, JSValueConst value,
+    JSClassID class_id)
+{
+    ngx_qjs_fetch_object_t  *object;
+
+    object = JS_GetOpaque2(cx, value, class_id);
+
+    return (object != NULL) ? object->data : NULL;
+}
+
+
 static JSValue
 ngx_qjs_fetch_request_ctor(JSContext *cx, JSValueConst new_target, int argc,
     JSValueConst *argv)
@@ -511,7 +554,10 @@ ngx_qjs_fetch_request_ctor(JSContext *cx, JSValueConst new_target, int argc,
         return JS_EXCEPTION;
     }
 
-    JS_SetOpaque(obj, request);
+    if (ngx_qjs_fetch_object_set(cx, obj, request) != NGX_OK) {
+        JS_FreeValue(cx, obj);
+        return JS_EXCEPTION;
+    }
 
     return obj;
 }
@@ -521,10 +567,11 @@ static ngx_int_t
 ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
     ngx_url_t *u, int argc, JSValueConst *argv)
 {
-    JSValue            input, init, value;
-    ngx_int_t          rc;
-    ngx_pool_t        *pool;
-    ngx_js_request_t  *orig;
+    JSValue                  input, init, value;
+    ngx_int_t                rc;
+    ngx_pool_t              *pool;
+    ngx_js_request_t         *orig;
+    ngx_qjs_fetch_object_t   *object;
 
     input = argv[0];
     if (JS_IsUndefined(input)) {
@@ -549,8 +596,6 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
     request->body.data = NULL;
     request->body.len = 0;
     request->headers.guard = GUARD_REQUEST;
-    ngx_qjs_arg(request->header_value) = JS_UNDEFINED;
-
     pool = ngx_qjs_external_pool(cx, JS_GetContextOpaque(cx));
 
     rc = ngx_list_init(&request->headers.header_list, pool, 4,
@@ -571,12 +616,14 @@ ngx_qjs_request_ctor(JSContext *cx, ngx_js_request_t *request,
         }
 
     } else {
-        orig = JS_GetOpaque(input, NGX_QJS_CLASS_ID_FETCH_REQUEST);
-        if (orig == NULL) {
+        object = JS_GetOpaque(input, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+        if (object == NULL) {
             JS_ThrowTypeError(cx,
                               "input is not string or a Request object");
             return NGX_ERROR;
         }
+
+        orig = object->data;
 
         request->url = orig->url;
         request->method = orig->method;
@@ -781,8 +828,6 @@ ngx_qjs_fetch_response_ctor(JSContext *cx, JSValueConst new_target, int argc,
 
     response->code = 200;
     response->headers.guard = GUARD_RESPONSE;
-    ngx_qjs_arg(response->header_value) = JS_UNDEFINED;
-
     ret = ngx_list_init(&response->headers.header_list, pool, 4,
                         sizeof(ngx_js_tb_elt_t));
     if (ret != NGX_OK) {
@@ -926,7 +971,10 @@ string:
         return JS_EXCEPTION;
     }
 
-    JS_SetOpaque(obj, response);
+    if (ngx_qjs_fetch_object_set(cx, obj, response) != NGX_OK) {
+        JS_FreeValue(cx, obj);
+        return JS_EXCEPTION;
+    }
 
     return obj;
 }
@@ -1194,8 +1242,6 @@ ngx_qjs_fetch_alloc(JSContext *cx, ngx_pool_t *pool, ngx_log_t *log,
     http->keepalive = (conf->fetch_keepalive > 0
                        && !ngx_js_conf_dynamic_proxy(conf));
 
-    ngx_qjs_arg(http->response.header_value) = JS_UNDEFINED;
-
     http->append_headers = ngx_qjs_fetch_append_headers;
     http->ready_handler = ngx_qjs_fetch_process_done;
     http->error_handler = ngx_qjs_fetch_error;
@@ -1354,7 +1400,15 @@ ngx_qjs_fetch_process_done(ngx_js_http_t *http)
         return;
     }
 
-    JS_SetOpaque(fetch->response_value, &http->response);
+    if (ngx_qjs_fetch_object_set(fetch->cx, fetch->response_value,
+                                 &http->response)
+        != NGX_OK)
+    {
+        JS_FreeValue(fetch->cx, fetch->response_value);
+        fetch->response_value = JS_UNDEFINED;
+        ngx_qjs_fetch_error(http, "fetch response creation failed");
+        return;
+    }
 
     ngx_qjs_fetch_done(fetch, fetch->response_value, NGX_OK);
 }
@@ -1933,7 +1987,8 @@ ngx_qjs_ext_fetch_request_body(JSContext *cx, JSValueConst this_val,
     JSValue            result;
     ngx_js_request_t  *request;
 
-    request = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    request = ngx_qjs_fetch_object_data(cx, this_val,
+                                        NGX_QJS_CLASS_ID_FETCH_REQUEST);
     if (request == NULL) {
         return JS_UNDEFINED;
     }
@@ -1998,7 +2053,8 @@ ngx_qjs_ext_fetch_request_body_used(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_request_t  *request;
 
-    request = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    request = ngx_qjs_fetch_object_data(cx, this_val,
+                                        NGX_QJS_CLASS_ID_FETCH_REQUEST);
     if (request == NULL) {
         return JS_UNDEFINED;
     }
@@ -2012,7 +2068,8 @@ ngx_qjs_ext_fetch_request_cache(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_request_t  *request;
 
-    request = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    request = ngx_qjs_fetch_object_data(cx, this_val,
+                                        NGX_QJS_CLASS_ID_FETCH_REQUEST);
     if (request == NULL) {
         return JS_UNDEFINED;
     }
@@ -2027,7 +2084,8 @@ ngx_qjs_ext_fetch_request_credentials(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_request_t  *request;
 
-    request = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    request = ngx_qjs_fetch_object_data(cx, this_val,
+                                        NGX_QJS_CLASS_ID_FETCH_REQUEST);
     if (request == NULL) {
         return JS_UNDEFINED;
     }
@@ -2040,15 +2098,17 @@ ngx_qjs_ext_fetch_request_credentials(JSContext *cx, JSValueConst this_val)
 static JSValue
 ngx_qjs_ext_fetch_request_headers(JSContext *cx, JSValueConst this_val)
 {
-    JSValue           header;
-    ngx_js_request_t  *request;
+    JSValue                  header;
+    ngx_js_request_t        *request;
+    ngx_qjs_fetch_object_t  *object;
 
-    request = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
-    if (request == NULL) {
+    object = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    if (object == NULL) {
         return JS_UNDEFINED;
     }
 
-    header = ngx_qjs_arg(request->header_value);
+    request = object->data;
+    header = object->header_value;
 
     if (JS_IsUndefined(header)) {
         header = JS_NewObjectClass(cx, NGX_QJS_CLASS_ID_FETCH_HEADERS);
@@ -2058,7 +2118,7 @@ ngx_qjs_ext_fetch_request_headers(JSContext *cx, JSValueConst this_val)
 
         JS_SetOpaque(header, &request->headers);
 
-        ngx_qjs_arg(request->header_value) = header;
+        object->header_value = header;
     }
 
     return JS_DupValue(cx, header);
@@ -2071,7 +2131,8 @@ ngx_qjs_ext_fetch_request_field(JSContext *cx, JSValueConst this_val, int magic)
     ngx_str_t         *field;
     ngx_js_request_t  *request;
 
-    request = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    request = ngx_qjs_fetch_object_data(cx, this_val,
+                                        NGX_QJS_CLASS_ID_FETCH_REQUEST);
     if (request == NULL) {
         return JS_UNDEFINED;
     }
@@ -2087,7 +2148,8 @@ ngx_qjs_ext_fetch_request_mode(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_request_t  *request;
 
-    request = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    request = ngx_qjs_fetch_object_data(cx, this_val,
+                                        NGX_QJS_CLASS_ID_FETCH_REQUEST);
     if (request == NULL) {
         return JS_UNDEFINED;
     }
@@ -2097,13 +2159,30 @@ ngx_qjs_ext_fetch_request_mode(JSContext *cx, JSValueConst this_val)
 
 
 static void
+ngx_qjs_fetch_request_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func)
+{
+    ngx_qjs_fetch_object_t  *object;
+
+    object = JS_GetOpaque(val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    if (object != NULL) {
+        JS_MarkValue(rt, object->header_value, mark_func);
+    }
+}
+
+
+static void
 ngx_qjs_fetch_request_finalizer(JSRuntime *rt, JSValue val)
 {
-    ngx_js_request_t  *request;
+    ngx_qjs_fetch_object_t  *object;
 
-    request = JS_GetOpaque(val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    object = JS_GetOpaque(val, NGX_QJS_CLASS_ID_FETCH_REQUEST);
+    if (object == NULL) {
+        return;
+    }
 
-    JS_FreeValueRT(rt, ngx_qjs_arg(request->header_value));
+    JS_FreeValueRT(rt, object->header_value);
+    js_free_rt(rt, object);
 }
 
 
@@ -2112,7 +2191,8 @@ ngx_qjs_ext_fetch_response_status(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2126,7 +2206,8 @@ ngx_qjs_ext_fetch_response_status_text(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2141,7 +2222,8 @@ ngx_qjs_ext_fetch_response_ok(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2155,7 +2237,8 @@ ngx_qjs_ext_fetch_response_body_used(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2167,15 +2250,17 @@ ngx_qjs_ext_fetch_response_body_used(JSContext *cx, JSValueConst this_val)
 static JSValue
 ngx_qjs_ext_fetch_response_headers(JSContext *cx, JSValueConst this_val)
 {
-    JSValue            header;
-    ngx_js_response_t  *response;
+    JSValue                  header;
+    ngx_js_response_t       *response;
+    ngx_qjs_fetch_object_t  *object;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
-    if (response == NULL) {
+    object = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    if (object == NULL) {
         return JS_UNDEFINED;
     }
 
-    header = ngx_qjs_arg(response->header_value);
+    response = object->data;
+    header = object->header_value;
 
     if (JS_IsUndefined(header)) {
         header = JS_NewObjectClass(cx, NGX_QJS_CLASS_ID_FETCH_HEADERS);
@@ -2185,7 +2270,7 @@ ngx_qjs_ext_fetch_response_headers(JSContext *cx, JSValueConst this_val)
 
         JS_SetOpaque(header, &response->headers);
 
-        ngx_qjs_arg(response->header_value) = header;
+        object->header_value = header;
     }
 
     return JS_DupValue(cx, header);
@@ -2197,7 +2282,8 @@ ngx_qjs_ext_fetch_response_type(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2215,7 +2301,8 @@ ngx_qjs_ext_fetch_response_body(JSContext *cx, JSValueConst this_val,
     njs_str_t           string;
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2281,7 +2368,8 @@ ngx_qjs_ext_fetch_response_redirected(JSContext *cx, JSValueConst this_val)
 {
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2296,7 +2384,8 @@ ngx_qjs_ext_fetch_response_field(JSContext *cx, JSValueConst this_val, int magic
     ngx_str_t          *field;
     ngx_js_response_t  *response;
 
-    response = JS_GetOpaque2(cx, this_val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    response = ngx_qjs_fetch_object_data(cx, this_val,
+                                         NGX_QJS_CLASS_ID_FETCH_RESPONSE);
     if (response == NULL) {
         return JS_UNDEFINED;
     }
@@ -2308,14 +2397,30 @@ ngx_qjs_ext_fetch_response_field(JSContext *cx, JSValueConst this_val, int magic
 
 
 static void
+ngx_qjs_fetch_response_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func)
+{
+    ngx_qjs_fetch_object_t  *object;
+
+    object = JS_GetOpaque(val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    if (object != NULL) {
+        JS_MarkValue(rt, object->header_value, mark_func);
+    }
+}
+
+
+static void
 ngx_qjs_fetch_response_finalizer(JSRuntime *rt, JSValue val)
 {
-    ngx_js_response_t  *response;
+    ngx_qjs_fetch_object_t  *object;
 
-    response = JS_GetOpaque(val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    object = JS_GetOpaque(val, NGX_QJS_CLASS_ID_FETCH_RESPONSE);
+    if (object == NULL) {
+        return;
+    }
 
-    JS_FreeValueRT(rt, ngx_qjs_arg(response->header_value));
-    njs_chb_destroy(&response->chain);
+    JS_FreeValueRT(rt, object->header_value);
+    js_free_rt(rt, object);
 }
 
 

--- a/nginx/ngx_stream_js_module.c
+++ b/nginx/ngx_stream_js_module.c
@@ -1194,6 +1194,7 @@ ngx_stream_js_variable_var(ngx_stream_session_t *s,
 static ngx_int_t
 ngx_stream_js_init_vm(ngx_stream_session_t *s, njs_int_t proto_id)
 {
+    ngx_engine_t             *engine;
     ngx_pool_cleanup_t        *cln;
     ngx_stream_js_ctx_t       *ctx;
     ngx_stream_js_srv_conf_t  *jscf;
@@ -1220,20 +1221,23 @@ ngx_stream_js_init_vm(ngx_stream_session_t *s, njs_int_t proto_id)
         return NGX_OK;
     }
 
-    ctx->engine = jscf->engine->clone((ngx_js_ctx_t *) ctx,
-                                      (ngx_js_loc_conf_t *) jscf, proto_id, s);
-    if (ctx->engine == NULL) {
+    engine = jscf->engine->clone((ngx_js_ctx_t *) ctx,
+                                 (ngx_js_loc_conf_t *) jscf, proto_id, s);
+    if (engine == NULL) {
         return NGX_ERROR;
     }
+
+    cln = ngx_pool_cleanup_add(s->connection->pool, 0);
+    if (cln == NULL) {
+        ngx_js_clone_abort((ngx_js_ctx_t *) ctx, engine);
+        return NGX_ERROR;
+    }
+
+    ctx->engine = engine;
 
     ngx_log_debug3(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
                    "stream js vm clone %s: %p from: %p", jscf->engine->name,
                    ctx->engine, jscf->engine);
-
-    cln = ngx_pool_cleanup_add(s->connection->pool, 0);
-    if (cln == NULL) {
-        return NGX_ERROR;
-    }
 
     cln->handler = ngx_stream_js_cleanup;
     cln->data = s;
@@ -2105,16 +2109,17 @@ ngx_engine_njs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         return NULL;
     }
 
-    sctx = (ngx_stream_js_ctx_t *) ctx;
-    sctx->run_event = ngx_stream_js_run_event;
-    sctx->body_filter = ngx_stream_njs_body_filter;
-
     rc = njs_vm_external_create(engine->u.njs.vm, njs_value_arg(&ctx->args[0]),
                                 proto_id, njs_vm_external_ptr(engine->u.njs.vm),
                                 0);
     if (rc != NJS_OK) {
+        ngx_js_clone_abort(ctx, engine);
         return NULL;
     }
+
+    sctx = (ngx_stream_js_ctx_t *) ctx;
+    sctx->run_event = ngx_stream_js_run_event;
+    sctx->body_filter = ngx_stream_njs_body_filter;
 
     return engine;
 }
@@ -3027,6 +3032,7 @@ ngx_stream_qjs_session_make(JSContext *cx, ngx_int_t proto_id,
 
     ses = js_malloc(cx, sizeof(ngx_stream_qjs_session_t));
     if (ses == NULL) {
+        JS_FreeValue(cx, session);
         return JS_ThrowOutOfMemory(cx);
     }
 
@@ -3113,12 +3119,12 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_STREAM_SESSION,
                         &ngx_stream_qjs_session_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         proto = JS_NewObject(cx);
         if (JS_IsException(proto)) {
-            return NULL;
+            goto failed;
         }
 
         JS_SetPropertyFunctionList(cx, proto, ngx_stream_qjs_ext_session,
@@ -3129,12 +3135,12 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_STREAM_PERIODIC,
                         &ngx_stream_qjs_periodic_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         proto = JS_NewObject(cx);
         if (JS_IsException(proto)) {
-            return NULL;
+            goto failed;
         }
 
         JS_SetPropertyFunctionList(cx, proto, ngx_stream_qjs_ext_periodic,
@@ -3145,12 +3151,12 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_STREAM_FLAGS,
                         &ngx_stream_qjs_flags_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
 
         proto = JS_NewObject(cx);
         if (JS_IsException(proto)) {
-            return NULL;
+            goto failed;
         }
 
         JS_SetPropertyFunctionList(cx, proto, ngx_stream_qjs_ext_flags,
@@ -3161,13 +3167,9 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
         if (JS_NewClass(JS_GetRuntime(cx), NGX_QJS_CLASS_ID_STREAM_VARS,
                         &ngx_stream_qjs_variables_class) < 0)
         {
-            return NULL;
+            goto failed;
         }
     }
-
-    sctx = (ngx_stream_js_ctx_t *) ctx;
-    sctx->run_event = ngx_stream_qjs_run_event;
-    sctx->body_filter = ngx_stream_qjs_body_filter;
 
     if (proto_id == ngx_stream_js_session_proto_id) {
         proto_id = NGX_QJS_CLASS_ID_STREAM_SESSION;
@@ -3179,10 +3181,20 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
     ngx_qjs_arg(ctx->args[0]) = ngx_stream_qjs_session_make(cx, proto_id,
                                                             external);
     if (JS_IsException(ngx_qjs_arg(ctx->args[0]))) {
-        return NULL;
+        goto failed;
     }
 
+    sctx = (ngx_stream_js_ctx_t *) ctx;
+    sctx->run_event = ngx_stream_qjs_run_event;
+    sctx->body_filter = ngx_stream_qjs_body_filter;
+
     return engine;
+
+failed:
+
+    ngx_js_clone_abort(ctx, engine);
+
+    return NULL;
 }
 
 

--- a/nginx/ngx_stream_js_module.c
+++ b/nginx/ngx_stream_js_module.c
@@ -1275,8 +1275,7 @@ ngx_stream_js_drop_events(ngx_stream_js_ctx_t *ctx)
 static void
 ngx_stream_js_cleanup(void *data)
 {
-    ngx_stream_js_ctx_t       *ctx;
-    ngx_stream_js_srv_conf_t  *jscf;
+    ngx_stream_js_ctx_t  *ctx;
 
     ngx_stream_session_t *s = data;
 
@@ -1289,9 +1288,7 @@ ngx_stream_js_cleanup(void *data)
     ngx_log_debug1(NGX_LOG_DEBUG_STREAM, ctx->log, 0,
                    "stream js vm destroy: %p", ctx->engine);
 
-    jscf = ngx_stream_get_module_srv_conf(s, ngx_stream_js_module);
-
-    ngx_js_ctx_destroy((ngx_js_ctx_t *) ctx, (ngx_js_loc_conf_t *) jscf);
+    ngx_js_ctx_destroy((ngx_js_ctx_t *) ctx);
 }
 
 

--- a/nginx/ngx_stream_js_module.c
+++ b/nginx/ngx_stream_js_module.c
@@ -194,6 +194,8 @@ static ngx_int_t ngx_stream_qjs_body_filter(ngx_stream_session_t *s,
 static ngx_stream_session_t *ngx_stream_qjs_session(JSValueConst val);
 static JSValue ngx_stream_qjs_session_make(JSContext *cx, ngx_int_t proto_id,
     ngx_stream_session_t *s);
+static void ngx_stream_qjs_session_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func);
 static void ngx_stream_qjs_session_finalizer(JSRuntime *rt, JSValue val);
 static void ngx_stream_qjs_periodic_finalizer(JSRuntime *rt, JSValue val);
 
@@ -882,6 +884,7 @@ static const JSCFunctionListEntry ngx_stream_qjs_ext_flags[] = {
 static JSClassDef ngx_stream_qjs_session_class = {
     "Session",
     .finalizer = ngx_stream_qjs_session_finalizer,
+    .gc_mark = ngx_stream_qjs_session_mark,
 };
 
 
@@ -3043,6 +3046,22 @@ ngx_stream_qjs_session_make(JSContext *cx, ngx_int_t proto_id,
 
 
 static void
+ngx_stream_qjs_session_mark(JSRuntime *rt, JSValueConst val,
+    JS_MarkFunc *mark_func)
+{
+    ngx_uint_t                 i;
+    ngx_stream_qjs_session_t  *ses;
+
+    ses = JS_GetOpaque(val, NGX_QJS_CLASS_ID_STREAM_SESSION);
+    if (ses != NULL) {
+        for (i = 0; i < NGX_JS_EVENT_MAX; i++) {
+            JS_MarkValue(rt, ses->callbacks[i], mark_func);
+        }
+    }
+}
+
+
+static void
 ngx_stream_qjs_session_finalizer(JSRuntime *rt, JSValue val)
 {
     ngx_uint_t                 i;
@@ -3170,33 +3189,6 @@ ngx_engine_qjs_clone(ngx_js_ctx_t *ctx, ngx_js_loc_conf_t *cf,
 }
 
 
-static void
-ngx_stream_qjs_destroy(ngx_engine_t *e, ngx_js_ctx_t *ctx,
-    ngx_js_loc_conf_t *conf)
-{
-    ngx_uint_t                 i;
-    JSValue                    cb;
-    ngx_stream_qjs_session_t  *ses;
-
-    if (ctx != NULL) {
-        /*
-         * explicitly freeing the callback functions
-         * to avoid circular references with the session object.
-         */
-        ses = JS_GetOpaque(ngx_qjs_arg(ctx->args[0]),
-                           NGX_QJS_CLASS_ID_STREAM_SESSION);
-        if (ses != NULL) {
-            for (i = 0; i < NGX_JS_EVENT_MAX; i++) {
-                cb = ses->callbacks[i];
-                ses->callbacks[i] = JS_UNDEFINED;
-                JS_FreeValue(e->u.qjs.ctx, cb);
-            }
-        }
-    }
-
-    ngx_engine_qjs_destroy(e, ctx, conf);
-}
-
 #endif
 
 
@@ -3224,7 +3216,6 @@ ngx_stream_js_init_conf_vm(ngx_conf_t *cf, ngx_js_loc_conf_t *conf)
         options.u.qjs.metas = ngx_stream_js_uptr;
         options.u.qjs.addons = njs_stream_qjs_addon_modules;
         options.clone = ngx_engine_qjs_clone;
-        options.destroy = ngx_stream_qjs_destroy;
 
         options.core_conf = (ngx_js_core_conf_t *)
                  ngx_get_conf(cf->cycle->conf_ctx, ngx_stream_js_core_module);

--- a/nginx/t/js_clone_failure.t
+++ b/nginx/t/js_clone_failure.t
@@ -1,0 +1,81 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) F5, Inc.
+
+# Tests for cleanup after a JavaScript context clone failure.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_engine njs;
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /failed {
+            js_content test.content;
+            js_body_filter test.filter;
+        }
+
+        location /alive {
+            return 200 alive;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<'EOF');
+    Promise.reject(new Error('unhandled'));
+    throw new Error('clone failed');
+
+    function content(r) {
+        r.return(200, 'unexpected');
+    }
+
+    function filter(r, data, flags) {
+        r.sendBuffer(data, flags);
+    }
+
+    export default { content, filter };
+
+EOF
+
+$t->try_run('no njs available')->plan(2);
+
+###############################################################################
+
+is(http_get('/failed'), '', 'clone failure');
+like(http_get('/alive'), qr/200 OK/, 'worker remains alive');
+
+###############################################################################

--- a/nginx/t/js_context_reuse_redirect.t
+++ b/nginx/t/js_context_reuse_redirect.t
@@ -1,0 +1,103 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) F5, Inc.
+
+# Tests for QuickJS context reuse after an internal redirect.  A context must
+# be returned to the reuse queue of the location that created it.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http/)
+	->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+worker_processes 1;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_engine qjs;
+    js_context_reuse 4;
+    js_context_reuse_max_size 64m;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location = /source {
+            js_import handler from source.js;
+            js_content handler.content;
+        }
+
+        location = /destination {
+            js_import handler from destination.js;
+            js_content handler.content;
+        }
+    }
+}
+
+EOF
+
+$t->write_file('source.js', <<'EOF');
+    let visits = 0;
+
+    function content(r) {
+        visits++;
+
+        if (r.uri == '/source') {
+            r.internalRedirect(`/destination?from=${visits}`);
+            return;
+        }
+
+        r.return(200, `source:${visits}`);
+    }
+
+    export default { content };
+
+EOF
+
+$t->write_file('destination.js', <<'EOF');
+    let visits = 0;
+
+    function content(r) {
+        visits++;
+        r.return(200, `destination:${visits}:from=${r.args.from || '-'}`);
+    }
+
+    export default { content };
+
+EOF
+
+$t->try_run('no njs available')->plan(4);
+
+###############################################################################
+
+like(http_get('/source'), qr/destination:1:from=1/, 'internal redirect');
+like(http_get('/destination'), qr/destination:2:from=-/, 'destination reuse');
+like(http_get('/destination'), qr/destination:3:from=-/,
+	'destination reuse queue isolation');
+like(http_get('/source'), qr/destination:4:from=2/,
+	'source reuse queue ownership');
+
+###############################################################################

--- a/nginx/t/js_fetch_object_lifetime.t
+++ b/nginx/t/js_fetch_object_lifetime.t
@@ -1,0 +1,158 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) F5, Inc.
+
+# Tests for QuickJS Fetch object finalization after pool destruction.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http rewrite/)
+    ->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+worker_processes 1;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_engine qjs;
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /reuse {
+            js_context_reuse 1;
+            js_content test.reuse;
+        }
+
+        location /no_reuse {
+            js_context_reuse 0;
+            js_content test.no_reuse;
+        }
+
+        location /target {
+            add_header X-Test preserved;
+            return 200 body;
+        }
+    }
+}
+
+EOF
+
+my $p0 = port(8080);
+
+$t->write_file('test.js', <<EOF);
+    var retained;
+
+    async function reuse(r) {
+        var result = 'ok';
+
+        switch (r.args.op) {
+        case 'request':
+            retained = new Request('http://127.0.0.1:$p0/', {
+                headers: {x: 'request'}
+            });
+            result = retained.headers.get('x');
+            break;
+
+        case 'response':
+            retained = new Response('response', {
+                headers: {x: 'response'}
+            });
+            result = retained.headers.get('x');
+            break;
+
+        case 'fetch':
+            retained = await ngx.fetch('http://127.0.0.1:$p0/target');
+            result = retained.headers.get('x-test');
+            break;
+
+        case 'release':
+            retained = null;
+            break;
+        }
+
+        r.return(200, result);
+    }
+
+    async function no_reuse(r) {
+        var object;
+
+        switch (r.args.type) {
+        case 'request':
+            object = new Request('http://127.0.0.1:$p0/');
+            break;
+
+        case 'response':
+            object = new Response('response');
+            break;
+
+        case 'fetch':
+            object = await ngx.fetch('http://127.0.0.1:$p0/target');
+            break;
+
+        case 'request_headers':
+            object = new Request('http://127.0.0.1:$p0/');
+            object.headers.owner = object;
+            r.return(200, 'ok');
+            return;
+
+        case 'response_headers':
+            object = new Response('response');
+            object.headers.owner = object;
+            r.return(200, 'ok');
+            return;
+        }
+
+        object.self = object;
+        r.return(200, 'ok');
+    }
+
+    export default {reuse, no_reuse};
+EOF
+
+$t->try_run('no QuickJS support')->plan(11);
+
+###############################################################################
+
+like(http_get('/reuse?op=request'), qr/request$/s, 'retain Request');
+like(http_get('/reuse?op=release'), qr/200 OK/, 'release Request');
+
+like(http_get('/reuse?op=response'), qr/response$/s, 'retain Response');
+like(http_get('/reuse?op=release'), qr/200 OK/, 'release Response');
+
+like(http_get('/reuse?op=fetch'), qr/preserved$/s, 'retain fetch Response');
+like(http_get('/reuse?op=release'), qr/200 OK/, 'release fetch Response');
+
+like(http_get('/no_reuse?type=request'), qr/200 OK/, 'Request cycle');
+like(http_get('/no_reuse?type=response'), qr/200 OK/, 'Response cycle');
+like(http_get('/no_reuse?type=fetch'), qr/200 OK/, 'fetch Response cycle');
+like(http_get('/no_reuse?type=request_headers'), qr/200 OK/,
+    'Request Headers cycle');
+like(http_get('/no_reuse?type=response_headers'), qr/200 OK/,
+    'Response Headers cycle');
+
+###############################################################################

--- a/nginx/t/js_qjs_gc_mark.t
+++ b/nginx/t/js_qjs_gc_mark.t
@@ -1,0 +1,140 @@
+#!/usr/bin/perl
+
+# (C) Dmitry Volyntsev
+# (C) F5, Inc.
+
+# Tests for JavaScript references held by QuickJS nginx wrapper classes.
+
+###############################################################################
+
+use warnings;
+use strict;
+
+use Test::More;
+
+BEGIN { use FindBin; chdir($FindBin::Bin); }
+
+use lib 'lib';
+use Test::Nginx;
+use Test::Nginx::Stream qw/ stream /;
+
+###############################################################################
+
+select STDERR; $| = 1;
+select STDOUT; $| = 1;
+
+my $t = Test::Nginx->new()->has(qw/http stream stream_return/)
+    ->write_file_expand('nginx.conf', <<'EOF');
+
+%%TEST_GLOBALS%%
+
+daemon off;
+
+events {
+}
+
+http {
+    %%TEST_GLOBALS_HTTP%%
+
+    js_engine qjs;
+    js_context_reuse 0;
+    js_import test.js;
+
+    server {
+        listen       127.0.0.1:8080;
+        server_name  localhost;
+
+        location /cycle {
+            js_content test.http_cycle;
+        }
+
+        location /request_body_cycle {
+            js_content test.request_body_cycle;
+        }
+
+        location /response_body_cycle {
+            js_content test.response_body_cycle;
+        }
+
+        location /body {
+            return 200 body;
+        }
+    }
+}
+
+stream {
+    %%TEST_GLOBALS_STREAM%%
+
+    js_engine qjs;
+    js_context_reuse 0;
+    js_import test.js;
+
+    server {
+        listen      127.0.0.1:8081;
+        js_preread  test.stream_cycle;
+        return      OK;
+    }
+}
+
+EOF
+
+$t->write_file('test.js', <<'EOF');
+    function http_cycle(r) {
+        r.args.request = r;
+        r.return(200, 'ok');
+    }
+
+    function request_body_cycle(r) {
+        var body = r.requestBuffer;
+
+        body.request = r;
+        r.return(200, body.length);
+    }
+
+    async function response_body_cycle(r) {
+        var reply = await r.subrequest('/body');
+        var body = reply.responseBuffer;
+
+        body.reply = reply;
+        r.return(200, body.length);
+    }
+
+    function stream_cycle(s) {
+        s.on('upload', function(data) {
+            if (data.length != 0) {
+                s.done();
+            }
+        });
+    }
+
+    export default {http_cycle, request_body_cycle, response_body_cycle,
+                    stream_cycle};
+EOF
+
+$t->try_run('no QuickJS support')->plan(4);
+
+###############################################################################
+
+# Disabling reuse forces JS_FreeRuntime() after each request or session.
+# A missing gc_mark leaves the cycle in the runtime and the harness catches
+# the resulting worker abort through its implicit no-alerts check.
+
+like(http_get('/cycle'), qr/200 OK/, 'HTTP request cycle');
+like(http_post('/request_body_cycle'), qr/200 OK/, 'request body cycle');
+like(http_get('/response_body_cycle'), qr/200 OK/, 'response body cycle');
+is(stream('127.0.0.1:' . port(8081))->io('x'), 'OK',
+    'stream session callback cycle');
+
+###############################################################################
+
+sub http_post {
+    my ($uri) = @_;
+    my $crlf = "\x0d\x0a";
+
+    return http("POST $uri HTTP/1.0" . $crlf
+        . "Host: localhost" . $crlf
+        . "Content-Length: 4" . $crlf . $crlf
+        . "body");
+}
+
+###############################################################################

--- a/src/qjs.c
+++ b/src/qjs.c
@@ -242,6 +242,8 @@ qjs_new_context(JSRuntime *rt, qjs_module_t **addons)
         return NULL;
     }
 
+    global_obj = JS_UNDEFINED;
+
     JS_AddIntrinsicBaseObjects(ctx);
     JS_AddIntrinsicDate(ctx);
     JS_AddIntrinsicRegExp(ctx);
@@ -257,14 +259,14 @@ qjs_new_context(JSRuntime *rt, qjs_module_t **addons)
 
     for (module = qjs_modules; *module != NULL; module++) {
         if ((*module)->init(ctx, (*module)->name) == NULL) {
-            return NULL;
+            goto failed;
         }
     }
 
     if (addons != NULL) {
         for (module = addons; *module != NULL; module++) {
             if ((*module)->init(ctx, (*module)->name) == NULL) {
-                return NULL;
+                goto failed;
             }
         }
     }
@@ -272,46 +274,53 @@ qjs_new_context(JSRuntime *rt, qjs_module_t **addons)
     global_obj = JS_GetGlobalObject(ctx);
 
     if (qjs_add_intrinsic_njs(ctx, global_obj) < 0) {
-        return NULL;
+        goto failed;
     }
 
     if (qjs_add_intrinsic_text_decoder(ctx, global_obj) < 0) {
-        return NULL;
+        goto failed;
     }
 
     if (qjs_add_intrinsic_text_encoder(ctx, global_obj) < 0) {
-        return NULL;
+        goto failed;
     }
 
     if (qjs_add_intrinsic_btoa_atob(ctx, global_obj) < 0) {
-        return NULL;
+        goto failed;
     }
 
     prop = JS_NewAtom(ctx, "eval");
     if (prop == JS_ATOM_NULL) {
-        return NULL;
+        goto failed;
     }
 
     ret = JS_DeleteProperty(ctx, global_obj, prop, 0);
     JS_FreeAtom(ctx, prop);
     if (ret < 0) {
-        return NULL;
+        goto failed;
     }
 
     prop = JS_NewAtom(ctx, "Function");
     if (prop == JS_ATOM_NULL) {
-        return NULL;
+        goto failed;
     }
 
     ret = JS_DeleteProperty(ctx, global_obj, prop, 0);
     JS_FreeAtom(ctx, prop);
     if (ret < 0) {
-        return NULL;
+        goto failed;
     }
 
     JS_FreeValue(ctx, global_obj);
 
     return ctx;
+
+failed:
+
+    JS_FreeValue(ctx, global_obj);
+    JS_FreeContext(ctx);
+
+    return NULL;
 }
 
 


### PR DESCRIPTION
The first set of robustness/hardening fixes for QuickJS with `js_context_reuse 0;`