### PR TITLE
String: fix out-of-bounds read in $' substitution expansion

### DIFF
--- a/src/njs_string.c
+++ b/src/njs_string.c
@@ -3000,7 +3000,9 @@ njs_string_get_substitution(njs_vm_t *vm, njs_value_t *matched,
             length = njs_string_prop(vm, &m, matched);
             (void) njs_string_prop(vm, &s, string);
 
-            tail = njs_string_offset(&s, pos + length) - s.start;
+            tail = njs_string_offset(&s, njs_min(pos + (int64_t) length,
+                                                 (int64_t) s.length))
+                   - s.start;
 
             njs_chb_append(&chain, &s.start[tail],
                            njs_max((int64_t) s.size - tail, 0));

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -10008,6 +10008,18 @@ static njs_unit_test_t  njs_test[] =
               "'ABC'.replaceAll(/B/g, '+')"),
       njs_str("A|+|C") },
 
+    { njs_str("var n = 0;"
+              "var re = { global: false, exec: function () {"
+              "    return n++ ? null : { 0: 'y'.repeat(100), index: 0 }; } };"
+              "RegExp.prototype[Symbol.replace].call(re, 'αβγ', \"[$']\")"),
+      njs_str("[]") },
+
+    { njs_str("var n = 0;"
+              "var re = { global: false, exec: function () {"
+              "    return n++ ? null : { 0: 'y'.repeat(1000), index: 2 }; } };"
+              "RegExp.prototype[Symbol.replace].call(re, 'αβγδε', \"<$'>\")"),
+      njs_str("αβ<>") },
+
     { njs_str("var O = RegExp.prototype.exec;"
               "function mangled(s) { var r = O.call(this, s);"
               "                      Object.defineProperty(r, '0', {enumerable:false}); "


### PR DESCRIPTION
### Proposed changes

The `$'` token in a replacement string expands to the part of the subject that comes after the match. `njs_string_get_substitution()` builds it with `njs_string_offset(&s, pos + length)`, where `length` is the character length of the matched text. `pos` is already clamped to the subject by every caller, but the matched length is taken as-is, and through `RegExp.prototype[Symbol.replace]` with a script-supplied `exec()` the match object's `[0]` can be any string, so `pos + length` can run well past the end of the subject. On a multibyte subject that pushes `njs_string_offset()` into `njs_string_utf8_offset()`, whose own comment notes it assumes a valid index and which reads the UTF-8 offset map without a bounds check, so the oversized index reads far outside the map. I noticed it while comparing the `$'` branch against the neighboring `` $` `` branch, which stays in range because it only uses the already-clamped `pos`. Clamping `pos + length` to the subject length before the offset call closes the read and matches the GetSubstitution step in the spec, where the tail starts at `min(position + matchLength, stringLength)`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
