### PR TITLE
Parser memory reduction

### DIFF
--- a/src/njs_disassembler.c
+++ b/src/njs_disassembler.c
@@ -202,6 +202,7 @@ njs_disassemble(u_char *start, u_char *end, njs_int_t count, njs_arr_t *lines)
     njs_vmcode_2addr_t           *code2;
     njs_vmcode_3addr_t           *code3;
     njs_vmcode_array_t           *array;
+    njs_vmcode_array_init_t      *array_init;
     njs_vmcode_catch_t           *catch;
     njs_vmcode_import_t          *import;
     njs_vmcode_finally_t         *finally;
@@ -238,6 +239,18 @@ njs_disassemble(u_char *start, u_char *end, njs_int_t count, njs_arr_t *lines)
                        (size_t) array->length, array->ctor ? " INIT" : "");
 
             p += sizeof(njs_vmcode_array_t);
+
+            continue;
+        }
+
+        if (operation == NJS_VMCODE_ARRAY_INIT) {
+            array_init = (njs_vmcode_array_init_t *) p;
+
+            njs_printf("%5uD | %05uz ARRAY INIT        %04Xz %04Xz %uD\n",
+                       line, p - start, (size_t) array_init->array,
+                       (size_t) array_init->value, array_init->index);
+
+            p += sizeof(njs_vmcode_array_init_t);
 
             continue;
         }

--- a/src/njs_function.c
+++ b/src/njs_function.c
@@ -989,6 +989,11 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_function_lambda_t   *lambda;
     const njs_token_type_t  *type;
 
+    njs_memzero(&chain, sizeof(njs_chb_t));
+    str.length = 0;
+    str.start = NULL;
+    parser.mem_pool = NULL;
+
     static const njs_token_type_t  safe_ast[] = {
         NJS_TOKEN_END,
         NJS_TOKEN_FUNCTION_EXPRESSION,
@@ -1023,7 +1028,7 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     for (i = 1; i < nargs - 1; i++) {
         ret = njs_value_to_chain(vm, &chain, njs_argument(args, i));
         if (njs_slow_path(ret < NJS_OK)) {
-            return ret;
+            goto done;
         }
 
         if (i != (nargs - 2)) {
@@ -1036,7 +1041,7 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     if (nargs > 1) {
         ret = njs_value_to_chain(vm, &chain, njs_argument(args, nargs - 1));
         if (njs_slow_path(ret < NJS_OK)) {
-            return ret;
+            goto done;
         }
     }
 
@@ -1045,7 +1050,8 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     ret = njs_chb_join(&chain, &str);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_memory_error(vm);
-        return NJS_ERROR;
+        ret = NJS_ERROR;
+        goto done;
     }
 
     file = njs_str_value("runtime");
@@ -1053,12 +1059,12 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     ret = njs_parser_init(vm, &parser, NULL, &file, str.start,
                           str.start + str.length);
     if (njs_slow_path(ret != NJS_OK)) {
-        return ret;
+        goto done;
     }
 
     ret = njs_parser(vm, &parser);
     if (njs_slow_path(ret != NJS_OK)) {
-        return ret;
+        goto done;
     }
 
     if (!vm->options.unsafe) {
@@ -1092,7 +1098,8 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     ret = njs_generator_init(&generator, &file, 0, 1);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
-        return NJS_ERROR;
+        ret = NJS_ERROR;
+        goto done;
     }
 
     code = njs_generate_scope(vm, &generator, parser.scope,
@@ -1102,24 +1109,25 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
             njs_internal_error(vm, "njs_generate_scope() failed");
         }
 
-        return NJS_ERROR;
+        ret = NJS_ERROR;
+        goto done;
     }
-
-    njs_chb_destroy(&chain);
 
     if ((code->end - code->start)
         != (sizeof(njs_vmcode_function_t) + sizeof(njs_vmcode_return_t))
         || ((njs_vmcode_generic_t *) code->start)->code != NJS_VMCODE_FUNCTION)
     {
         njs_syntax_error(vm, "single function literal required");
-        return NJS_ERROR;
+        ret = NJS_ERROR;
+        goto done;
     }
 
     lambda = ((njs_vmcode_function_t *) code->start)->lambda;
 
     function = njs_function_alloc(vm, lambda, (njs_bool_t) async);
     if (njs_slow_path(function == NULL)) {
-        return NJS_ERROR;
+        ret = NJS_ERROR;
+        goto done;
     }
 
     function->global = 1;
@@ -1130,17 +1138,32 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     ret = njs_function_name_set(vm, function, &name, NULL);
     if (njs_slow_path(ret == NJS_ERROR)) {
-        return ret;
+        goto done;
     }
 
     njs_set_function(retval, function);
 
-    return NJS_OK;
+    ret = NJS_OK;
+    goto done;
 
 fail:
 
     njs_type_error(vm, "function constructor is disabled in \"safe\" mode");
-    return NJS_ERROR;
+    ret = NJS_ERROR;
+
+done:
+
+    if (parser.mem_pool != NULL) {
+        njs_parser_destroy(&parser);
+    }
+
+    njs_chb_destroy(&chain);
+
+    if (str.start != NULL) {
+        njs_mp_free(vm->mem_pool, str.start);
+    }
+
+    return ret;
 }
 
 

--- a/src/njs_function.c
+++ b/src/njs_function.c
@@ -1056,7 +1056,7 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
 
     file = njs_str_value("runtime");
 
-    ret = njs_parser_init(vm, &parser, NULL, &file, str.start,
+    ret = njs_parser_init(vm, &parser, NULL, 0, &file, str.start,
                           str.start + str.length);
     if (njs_slow_path(ret != NJS_OK)) {
         goto done;

--- a/src/njs_function.c
+++ b/src/njs_function.c
@@ -1095,7 +1095,7 @@ njs_function_constructor(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
         }
     }
 
-    ret = njs_generator_init(&generator, &file, 0, 1);
+    ret = njs_generator_init(&generator, parser.mem_pool, &file, 0, 1);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
         ret = NJS_ERROR;

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -643,6 +643,20 @@ static const njs_str_t  return_label = njs_str("@return");
 static const njs_str_t  undef_label  = { 0xffffffff, (u_char *) "" };
 
 
+njs_inline const njs_str_t *
+njs_generate_node_label(njs_vm_t *vm, njs_parser_node_t *node,
+    njs_str_t *label)
+{
+    if (node->u.label == NJS_ATOM_STRING_unknown) {
+        return &no_label;
+    }
+
+    njs_atom_string_get(vm, node->u.label, label);
+
+    return label;
+}
+
+
 njs_int_t
 njs_generator_init(njs_generator_t *generator, njs_str_t *file,
     njs_int_t depth, njs_bool_t runtime)
@@ -1297,9 +1311,10 @@ njs_generate_if_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
     njs_int_t  ret;
+    njs_str_t  label;
 
     ret = njs_generate_start_block(vm, generator, NJS_GENERATOR_BLOCK,
-                                    &node->name);
+                         njs_generate_node_label(vm, node, &label));
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -1545,6 +1560,7 @@ njs_generate_switch_expression(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *swtch)
 {
     njs_int_t                   ret;
+    njs_str_t                   label;
     njs_parser_node_t           *expr;
     njs_vmcode_move_t           *move;
     njs_generator_switch_ctx_t  *ctx;
@@ -1564,7 +1580,7 @@ njs_generate_switch_expression(njs_vm_t *vm, njs_generator_t *generator,
     }
 
     ret = njs_generate_start_block(vm, generator, NJS_GENERATOR_SWITCH,
-                                   &swtch->name);
+                         njs_generate_node_label(vm, swtch, &label));
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -1769,6 +1785,7 @@ njs_generate_while_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
     njs_int_t                 ret;
+    njs_str_t                 label;
     njs_vmcode_jump_t         *jump;
     njs_generator_loop_ctx_t  ctx;
 
@@ -1782,7 +1799,7 @@ njs_generate_while_statement(njs_vm_t *vm, njs_generator_t *generator,
     ctx.jump_offset = njs_code_offset(generator, jump);
 
     ret = njs_generate_start_block(vm, generator, NJS_GENERATOR_LOOP,
-                                   &node->name);
+                         njs_generate_node_label(vm, node, &label));
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -1851,10 +1868,11 @@ njs_generate_do_while_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
     njs_int_t                 ret;
+    njs_str_t                 label;
     njs_generator_loop_ctx_t  ctx;
 
     ret = njs_generate_start_block(vm, generator, NJS_GENERATOR_LOOP,
-                                   &node->name);
+                         njs_generate_node_label(vm, node, &label));
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -1918,10 +1936,11 @@ njs_generate_for_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
     njs_int_t                 ret;
+    njs_str_t                 label;
     njs_generator_loop_ctx_t  ctx;
 
     ret = njs_generate_start_block(vm, generator, NJS_GENERATOR_LOOP,
-                                   &node->name);
+                         njs_generate_node_label(vm, node, &label));
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -2291,11 +2310,12 @@ njs_generate_for_in_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
     njs_int_t                 ret;
+    njs_str_t                 label;
     njs_parser_node_t         *foreach, *name;
     njs_generator_loop_ctx_t  ctx;
 
     ret = njs_generate_start_block(vm, generator, NJS_GENERATOR_LOOP,
-                                   &node->name);
+                         njs_generate_node_label(vm, node, &label));
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -2851,12 +2871,13 @@ static njs_int_t
 njs_generate_continue_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
+    njs_str_t              name;
     const njs_str_t        *label, *dest;
     njs_vmcode_jump_t      *jump;
     njs_generator_patch_t  *patch;
     njs_generator_block_t  *block;
 
-    label = &node->name;
+    label = njs_generate_node_label(vm, node, &name);
 
     block = njs_generate_find_block(vm, generator->block, NJS_GENERATOR_LOOP,
                                     label);
@@ -2900,12 +2921,13 @@ static njs_int_t
 njs_generate_break_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
+    njs_str_t              name;
     const njs_str_t        *label, *dest;
     njs_vmcode_jump_t      *jump;
     njs_generator_patch_t  *patch;
     njs_generator_block_t  *block;
 
-    label = &node->name;
+    label = njs_generate_node_label(vm, node, &name);
 
     block = njs_generate_find_block(vm, generator->block, NJS_GENERATOR_ALL,
                                     label);
@@ -3012,10 +3034,11 @@ njs_generate_block_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
     njs_int_t         ret;
+    njs_str_t         label;
     njs_queue_link_t  *link;
 
     ret = njs_generate_start_block(vm, generator, NJS_GENERATOR_BLOCK,
-                                   &node->name);
+                         njs_generate_node_label(vm, node, &label));
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -4981,6 +4981,8 @@ njs_generate_scope(njs_vm_t *vm, njs_generator_t *generator,
         return NULL;
     }
 
+    code->start = NULL;
+    code->end = NULL;
     code->lines = NULL;
 
     if (vm->options.backtrace) {
@@ -5074,6 +5076,29 @@ njs_generate_scope(njs_vm_t *vm, njs_generator_t *generator,
     scope->top = NULL;
 
     return code;
+}
+
+
+void
+njs_generator_cleanup(njs_vm_t *vm, njs_uint_t code_index)
+{
+    njs_vm_code_t  *code;
+
+    if (vm->codes == NULL) {
+        return;
+    }
+
+    while (vm->codes->items > code_index) {
+        code = njs_arr_remove_last(vm->codes);
+
+        if (code->start != NULL) {
+            njs_mp_free(vm->mem_pool, code->start);
+        }
+
+        if (code->lines != NULL) {
+            njs_arr_destroy(code->lines);
+        }
+    }
 }
 
 

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -1097,7 +1097,7 @@ njs_generate_name(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_scope_t     *scope;
     njs_vmcode_variable_t  *variable;
 
-    var = njs_variable_reference(vm, node);
+    var = njs_variable_reference(vm, generator->mem_pool, node);
     if (njs_slow_path(var == NULL)) {
         ret = njs_generate_global_reference(vm, generator, node, 1);
         if (njs_slow_path(ret != NJS_OK)) {
@@ -1133,7 +1133,7 @@ njs_generate_variable(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_scope_t     *scope;
     njs_vmcode_variable_t  *variable;
 
-    var = njs_variable_reference(vm, node);
+    var = njs_variable_reference(vm, generator->mem_pool, node);
 
     if (retvar != NULL) {
         *retvar = var;
@@ -2213,7 +2213,7 @@ njs_generate_for_in_name_assign(njs_vm_t *vm, njs_generator_t *generator,
     lvalue = foreach->left;
     expr = node->right;
 
-    var = njs_variable_reference(vm, lvalue);
+    var = njs_variable_reference(vm, generator->mem_pool, lvalue);
 
     if (var != NULL) {
         ctx->index_next_value = lvalue->index;
@@ -3003,7 +3003,7 @@ njs_generate_statement(njs_vm_t *vm, njs_generator_t *generator,
     right = node->right;
 
     if (right != NULL && right->token_type == NJS_TOKEN_NAME) {
-        var = njs_variable_reference(vm, right);
+        var = njs_variable_reference(vm, generator->mem_pool, right);
         if (njs_slow_path(var == NULL)) {
             goto statement;
         }
@@ -3178,7 +3178,7 @@ njs_generate_global_property_set(njs_vm_t *vm, njs_generator_t *generator,
     njs_variable_t         *var;
     njs_vmcode_prop_set_t  *prop_set;
 
-    var = njs_variable_reference(vm, node_dst);
+    var = njs_variable_reference(vm, generator->mem_pool, node_dst);
     if (var == NULL) {
         njs_generate_code(generator, njs_vmcode_prop_set_t, prop_set,
                           NJS_VMCODE_PROPERTY_ATOM_SET, node_src);
@@ -4102,7 +4102,7 @@ njs_generate_function_expression(njs_vm_t *vm, njs_generator_t *generator,
     njs_function_lambda_t  *lambda;
     njs_vmcode_function_t  *function;
 
-    var = njs_variable_reference(vm, node->left);
+    var = njs_variable_reference(vm, generator->mem_pool, node->left);
     if (njs_slow_path(var == NULL)) {
         ret = njs_generate_reference_error(vm, generator, node->left);
         if (njs_slow_path(ret != NJS_OK)) {
@@ -4843,7 +4843,7 @@ njs_generate_function_declaration(njs_vm_t *vm, njs_generator_t *generator,
     njs_function_t         *function;
     njs_function_lambda_t  *lambda;
 
-    var = njs_variable_reference(vm, node);
+    var = njs_variable_reference(vm, generator->mem_pool, node);
     if (njs_slow_path(var == NULL)) {
         ret = njs_generate_reference_error(vm, generator, node);
         if (njs_slow_path(ret != NJS_OK)) {
@@ -4884,8 +4884,10 @@ njs_generate_function_scope(njs_vm_t *vm, njs_generator_t *prev,
     njs_function_lambda_t *lambda, njs_parser_node_t *node,
     const njs_str_t *name)
 {
+    size_t           size;
     njs_int_t        ret;
     njs_uint_t       depth;
+    njs_index_t      *closures;
     njs_vm_code_t    *code;
     njs_generator_t  generator;
 
@@ -4915,9 +4917,21 @@ njs_generate_function_scope(njs_vm_t *vm, njs_generator_t *prev,
     }
 
     lambda->start = generator.code_start;
-    lambda->closures = generator.closures->start;
     lambda->nclosures = generator.closures->items;
     lambda->nlocal = node->scope->items;
+
+    if (lambda->nclosures != 0) {
+        size = lambda->nclosures * sizeof(njs_index_t);
+
+        closures = njs_mp_alloc(vm->mem_pool, size);
+        if (njs_slow_path(closures == NULL)) {
+            njs_memory_error(vm);
+            return NJS_ERROR;
+        }
+
+        memcpy(closures, generator.closures->start, size);
+        lambda->closures = closures;
+    }
 
     return NJS_OK;
 }
@@ -4980,7 +4994,8 @@ njs_generate_scope(njs_vm_t *vm, njs_generator_t *generator,
         generator->lines = code->lines;
     }
 
-    generator->closures = njs_arr_create(vm->mem_pool, 4, sizeof(njs_index_t));
+    generator->closures = njs_arr_create(generator->mem_pool, 4,
+                                         sizeof(njs_index_t));
     if (njs_slow_path(generator->closures == NULL)) {
         return NULL;
     }
@@ -5860,7 +5875,7 @@ njs_generate_try_left(njs_vm_t *vm, njs_generator_t *generator,
     if (node->token_type == NJS_TOKEN_CATCH) {
         /* A "try/catch" case. */
 
-        var = njs_variable_reference(vm, node->left);
+        var = njs_variable_reference(vm, generator->mem_pool, node->left);
         if (njs_slow_path(var == NULL)) {
             return NJS_ERROR;
         }
@@ -5879,7 +5894,8 @@ njs_generate_try_left(njs_vm_t *vm, njs_generator_t *generator,
     if (node->left != NULL) {
         /* A try/catch/finally case. */
 
-        var = njs_variable_reference(vm, node->left->left);
+        var = njs_variable_reference(vm, generator->mem_pool,
+                                     node->left->left);
         if (njs_slow_path(var == NULL)) {
             return NJS_ERROR;
         }
@@ -6241,7 +6257,7 @@ njs_generate_import_statement(njs_vm_t *vm, njs_generator_t *generator,
 
     lvalue = node->left;
 
-    var = njs_variable_reference(vm, lvalue);
+    var = njs_variable_reference(vm, generator->mem_pool, lvalue);
     if (njs_slow_path(var == NULL)) {
         return NJS_ERROR;
     }

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -295,7 +295,7 @@ static njs_int_t njs_generate_for_end(njs_vm_t *vm, njs_generator_t *generator,
 static njs_int_t njs_generate_for_let_update(njs_vm_t *vm,
     njs_generator_t *generator, njs_parser_node_t *node);
 static njs_int_t njs_generate_for_resolve_closure(njs_vm_t *vm,
-    njs_parser_node_t *node);
+    njs_generator_t *generator, njs_parser_node_t *node);
 static njs_int_t njs_generate_for_in_statement(njs_vm_t *vm,
     njs_generator_t *generator, njs_parser_node_t *node);
 static njs_int_t njs_generate_for_in_set_prop_block(njs_vm_t *vm,
@@ -322,11 +322,11 @@ static njs_generator_block_t *njs_generate_find_block(njs_vm_t *vm,
 static void njs_generate_patch_block(njs_vm_t *vm, njs_generator_t *generator,
     njs_generator_block_t *block, unsigned type);
 static njs_generator_patch_t *njs_generate_make_continuation_patch(njs_vm_t *vm,
-    njs_generator_block_t *block, const njs_str_t *label,
-    njs_jump_off_t offset);
+    njs_generator_t *generator, njs_generator_block_t *block,
+    const njs_str_t *label, njs_jump_off_t offset);
 static njs_generator_patch_t *njs_generate_make_exit_patch(njs_vm_t *vm,
-    njs_generator_block_t *block, const njs_str_t *label,
-    njs_jump_off_t offset);
+    njs_generator_t *generator, njs_generator_block_t *block,
+    const njs_str_t *label, njs_jump_off_t offset);
 static void njs_generate_patch_block_exit(njs_vm_t *vm,
     njs_generator_t *generator);
 static const njs_str_t *njs_generate_jump_destination(njs_vm_t *vm,
@@ -658,13 +658,14 @@ njs_generate_node_label(njs_vm_t *vm, njs_parser_node_t *node,
 
 
 njs_int_t
-njs_generator_init(njs_generator_t *generator, njs_str_t *file,
-    njs_int_t depth, njs_bool_t runtime)
+njs_generator_init(njs_generator_t *generator, njs_mp_t *mem_pool,
+    njs_str_t *file, njs_int_t depth, njs_bool_t runtime)
 {
     njs_memzero(generator, sizeof(njs_generator_t));
 
     njs_queue_init(&generator->stack);
 
+    generator->mem_pool = mem_pool;
     generator->file = *file;
     generator->depth = depth;
     generator->runtime = runtime;
@@ -689,7 +690,8 @@ njs_generator_after(njs_vm_t *vm, njs_generator_t *generator,
 {
     njs_generator_stack_entry_t  *entry;
 
-    entry = njs_mp_alloc(vm->mem_pool, sizeof(njs_generator_stack_entry_t));
+    entry = njs_mp_alloc(generator->mem_pool,
+                         sizeof(njs_generator_stack_entry_t));
     if (njs_slow_path(entry == NULL)) {
         return NJS_ERROR;
     }
@@ -701,7 +703,7 @@ njs_generator_after(njs_vm_t *vm, njs_generator_t *generator,
     njs_queue_insert_before(link, &entry->link);
 
     if (size > 0) {
-        entry->context = njs_mp_alloc(vm->mem_pool, size);
+        entry->context = njs_mp_alloc(generator->mem_pool, size);
         if (njs_slow_path(entry->context == NULL)) {
             return NJS_ERROR;
         }
@@ -726,14 +728,14 @@ njs_generator_stack_pop(njs_vm_t *vm, njs_generator_t *generator, void *ctx)
     njs_queue_remove(link);
 
     if (ctx != NULL) {
-        njs_mp_free(vm->mem_pool, ctx);
+        njs_mp_free(generator->mem_pool, ctx);
     }
 
     generator->context = entry->context;
 
     njs_generator_next(generator, entry->state, entry->node);
 
-    njs_mp_free(vm->mem_pool, entry);
+    njs_mp_free(generator->mem_pool, entry);
 
     return NJS_OK;
 }
@@ -1648,7 +1650,8 @@ njs_generate_switch_case_after(njs_vm_t *vm, njs_generator_t *generator,
         return ret;
     }
 
-    patch = njs_mp_alloc(vm->mem_pool, sizeof(njs_generator_patch_t));
+    patch = njs_mp_alloc(generator->mem_pool,
+                         sizeof(njs_generator_patch_t));
     if (njs_slow_path(patch == NULL)) {
         return NJS_ERROR;
     }
@@ -1737,7 +1740,7 @@ njs_generate_switch_default(njs_vm_t *vm, njs_generator_t *generator,
 
         next = ctx->patch->next;
 
-        njs_mp_free(vm->mem_pool, ctx->patch);
+        njs_mp_free(generator->mem_pool, ctx->patch);
 
         ctx->patch = next;
         node = branch->right;
@@ -1978,7 +1981,7 @@ njs_generate_for_init(njs_vm_t *vm, njs_generator_t *generator,
      * foreseen in order to generate optimized code for let updates.
      */
 
-    ret = njs_generate_for_resolve_closure(vm, condition);
+    ret = njs_generate_for_resolve_closure(vm, generator, condition);
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -2022,7 +2025,7 @@ njs_generate_for_body(njs_vm_t *vm, njs_generator_t *generator,
     init = node->left;
     update = node->right->right->right;
 
-    ret = njs_generate_for_resolve_closure(vm, update);
+    ret = njs_generate_for_resolve_closure(vm, generator, update);
     if (njs_slow_path(ret != NJS_OK)) {
         return ret;
     }
@@ -2186,9 +2189,10 @@ njs_generate_for_resolve_closure_cb(njs_vm_t *vm, njs_parser_node_t *node,
 
 
 static njs_int_t
-njs_generate_for_resolve_closure(njs_vm_t *vm, njs_parser_node_t *node)
+njs_generate_for_resolve_closure(njs_vm_t *vm, njs_generator_t *generator,
+    njs_parser_node_t *node)
 {
-    return njs_parser_traverse(vm, node, NULL,
+    return njs_parser_traverse(vm, generator->mem_pool, node, NULL,
                                njs_generate_for_resolve_closure_cb);
 }
 
@@ -2634,7 +2638,8 @@ njs_generate_start_block(njs_vm_t *vm, njs_generator_t *generator,
 {
     njs_generator_block_t  *block;
 
-    block = njs_mp_alloc(vm->mem_pool, sizeof(njs_generator_block_t));
+    block = njs_mp_alloc(generator->mem_pool,
+                         sizeof(njs_generator_block_t));
 
     if (njs_fast_path(block != NULL)) {
         block->next = generator->block;
@@ -2730,12 +2735,13 @@ njs_generate_find_block(njs_vm_t *vm, njs_generator_block_t *block,
 
 
 static njs_generator_patch_t *
-njs_generate_make_continuation_patch(njs_vm_t *vm, njs_generator_block_t *block,
+njs_generate_make_continuation_patch(njs_vm_t *vm,
+    njs_generator_t *generator, njs_generator_block_t *block,
     const njs_str_t *label, njs_jump_off_t offset)
 {
     njs_generator_patch_t  *patch;
 
-    patch = njs_mp_alloc(vm->mem_pool, sizeof(njs_generator_patch_t));
+    patch = njs_mp_alloc(generator->mem_pool, sizeof(njs_generator_patch_t));
     if (njs_slow_path(patch == NULL)) {
         njs_memory_error(vm);
         return NULL;
@@ -2770,7 +2776,7 @@ njs_generate_patch(njs_vm_t *vm, njs_generator_t *generator,
                             &patch->label);
         next = patch->next;
 
-        njs_mp_free(vm->mem_pool, patch);
+        njs_mp_free(generator->mem_pool, patch);
     }
 }
 
@@ -2792,12 +2798,13 @@ njs_generate_patch_block(njs_vm_t *vm, njs_generator_t *generator,
 
 
 static njs_generator_patch_t *
-njs_generate_make_exit_patch(njs_vm_t *vm, njs_generator_block_t *block,
-    const njs_str_t *label, njs_jump_off_t offset)
+njs_generate_make_exit_patch(njs_vm_t *vm, njs_generator_t *generator,
+    njs_generator_block_t *block, const njs_str_t *label,
+    njs_jump_off_t offset)
 {
     njs_generator_patch_t  *patch;
 
-    patch = njs_mp_alloc(vm->mem_pool, sizeof(njs_generator_patch_t));
+    patch = njs_mp_alloc(generator->mem_pool, sizeof(njs_generator_patch_t));
     if (njs_slow_path(patch == NULL)) {
         njs_memory_error(vm);
         return NULL;
@@ -2829,7 +2836,7 @@ njs_generate_patch_block_exit(njs_vm_t *vm, njs_generator_t *generator)
 
     njs_debug_generator(vm, "EXIT  %s %p", njs_block_type(block->type), block);
 
-    njs_mp_free(vm->mem_pool, block);
+    njs_mp_free(generator->mem_pool, block);
 }
 
 
@@ -2899,7 +2906,7 @@ njs_generate_continue_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_generate_code_jump(generator, jump,
                            offsetof(njs_vmcode_jump_t, offset));
 
-    patch = njs_generate_make_continuation_patch(vm, block, label,
+    patch = njs_generate_make_continuation_patch(vm, generator, block, label,
                                          njs_code_offset(generator, jump)
                                          + offsetof(njs_vmcode_jump_t, offset));
     if (njs_slow_path(patch == NULL)) {
@@ -2947,7 +2954,7 @@ njs_generate_break_statement(njs_vm_t *vm, njs_generator_t *generator,
     njs_generate_code_jump(generator, jump,
                            offsetof(njs_vmcode_jump_t, offset));
 
-    patch = njs_generate_make_exit_patch(vm, block, label,
+    patch = njs_generate_make_exit_patch(vm, generator, block, label,
                                          njs_code_offset(generator, jump)
                                          + offsetof(njs_vmcode_jump_t, offset));
     if (njs_slow_path(patch == NULL)) {
@@ -3695,7 +3702,7 @@ njs_generate_operation_assignment_name(njs_vm_t *vm, njs_generator_t *generator,
         }
     }
 
-    njs_mp_free(vm->mem_pool, generator->context);
+    njs_mp_free(generator->mem_pool, generator->context);
 
     return njs_generate_node_index_release_pop(vm, generator, expr);
 }
@@ -4814,7 +4821,7 @@ found:
         }
     }
 
-    njs_mp_free(vm->mem_pool, generator->context);
+    njs_mp_free(generator->mem_pool, generator->context);
 
     ret = njs_generate_children_indexes_release(vm, generator, lvalue);
     if (njs_slow_path(ret != NJS_OK)) {
@@ -4889,7 +4896,8 @@ njs_generate_function_scope(njs_vm_t *vm, njs_generator_t *prev,
         return NJS_ERROR;
     }
 
-    ret = njs_generator_init(&generator, &prev->file, depth, prev->runtime);
+    ret = njs_generator_init(&generator, prev->mem_pool, &prev->file, depth,
+                             prev->runtime);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
         return NJS_ERROR;
@@ -5037,6 +5045,10 @@ njs_generate_scope(njs_vm_t *vm, njs_generator_t *generator,
         generator->code_end = code_start + code_size + prelude;
     }
 
+    if (arr != NULL) {
+        njs_arr_destroy(arr);
+    }
+
     code = njs_arr_item(vm->codes, index);
     code->start = generator->code_start;
     code->end = generator->code_end;
@@ -5175,7 +5187,8 @@ njs_generate_return_statement_end(njs_vm_t *vm, njs_generator_t *generator,
     try_return->save = top->index;
     try_return->offset = offsetof(njs_vmcode_try_return_t, offset);
 
-    patch = njs_generate_make_exit_patch(vm, immediate, &return_label,
+    patch = njs_generate_make_exit_patch(vm, generator, immediate,
+                                         &return_label,
                                          njs_code_offset(generator, try_return)
                                          + offsetof(njs_vmcode_try_return_t,
                                                     offset));
@@ -5941,7 +5954,7 @@ njs_generate_try_catch(njs_vm_t *vm, njs_generator_t *generator,
                                             NJS_GENERATOR_LOOP,
                                             &ctx->try_cont_label);
 
-            patch = njs_generate_make_continuation_patch(vm, block,
+            patch = njs_generate_make_continuation_patch(vm, generator, block,
                                                          &ctx->try_cont_label,
                         njs_code_offset(generator, finally)
                          + offsetof(njs_vmcode_finally_t, continue_offset));
@@ -5961,7 +5974,7 @@ njs_generate_try_catch(njs_vm_t *vm, njs_generator_t *generator,
              */
 
             if (block != NULL) {
-                patch = njs_generate_make_exit_patch(vm, block,
+                patch = njs_generate_make_exit_patch(vm, generator, block,
                                                      &ctx->try_exit_label,
                             njs_code_offset(generator, finally)
                             + offsetof(njs_vmcode_finally_t, break_offset));
@@ -5981,7 +5994,8 @@ njs_generate_try_catch(njs_vm_t *vm, njs_generator_t *generator,
                                                 &no_label);
 
                 if (block != NULL) {
-                    patch = njs_generate_make_exit_patch(vm, block, &no_label,
+                    patch = njs_generate_make_exit_patch(vm, generator, block,
+                                                         &no_label,
                                 njs_code_offset(generator, finally)
                                 + offsetof(njs_vmcode_finally_t, break_offset));
                     if (njs_slow_path(patch == NULL)) {
@@ -6128,7 +6142,8 @@ njs_generate_try_end(njs_vm_t *vm, njs_generator_t *generator,
         block = njs_generate_find_block(vm, generator->block,
                                         NJS_GENERATOR_LOOP, dest_label);
 
-        patch = njs_generate_make_continuation_patch(vm, block, dest_label,
+        patch = njs_generate_make_continuation_patch(vm, generator, block,
+                                                     dest_label,
                          njs_code_offset(generator, finally)
                          + offsetof(njs_vmcode_finally_t, continue_offset));
         if (njs_slow_path(patch == NULL)) {
@@ -6156,7 +6171,8 @@ njs_generate_try_end(njs_vm_t *vm, njs_generator_t *generator,
         block = njs_generate_find_block(vm, generator->block,
                                         NJS_GENERATOR_ALL, dest_label);
         if (block != NULL) {
-            patch = njs_generate_make_exit_patch(vm, block, dest_label,
+            patch = njs_generate_make_exit_patch(vm, generator, block,
+                                                 dest_label,
                             njs_code_offset(generator, finally)
                             + offsetof(njs_vmcode_finally_t, break_offset));
             if (njs_slow_path(patch == NULL)) {
@@ -6168,7 +6184,8 @@ njs_generate_try_end(njs_vm_t *vm, njs_generator_t *generator,
             block = njs_generate_find_block(vm, generator->block,
                                             NJS_GENERATOR_ALL, &no_label);
             if (block != NULL) {
-                patch = njs_generate_make_exit_patch(vm, block, &no_label,
+                patch = njs_generate_make_exit_patch(vm, generator, block,
+                                                     &no_label,
                                 njs_code_offset(generator, finally)
                                 + offsetof(njs_vmcode_finally_t, break_offset));
                 if (njs_slow_path(patch == NULL)) {
@@ -6553,7 +6570,7 @@ njs_generate_index_release(njs_vm_t *vm, njs_generator_t *generator,
     cache = generator->index_cache;
 
     if (cache == NULL) {
-        cache = njs_arr_create(vm->mem_pool, 4, sizeof(njs_value_t *));
+        cache = njs_arr_create(generator->mem_pool, 4, sizeof(njs_value_t *));
         if (njs_slow_path(cache == NULL)) {
             return NJS_ERROR;
         }

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -11,6 +11,7 @@
 
 
 #define NJS_FUNCTION_MAX_DEPTH  128
+#define NJS_PRESERVATION_MAX_DEPTH  128
 
 
 typedef struct njs_generator_patch_s   njs_generator_patch_t;
@@ -221,6 +222,67 @@ njs_generate_function_call_this(njs_parser_node_t *node)
     njs_assert(node->token_type == NJS_TOKEN_FUNCTION_CALL);
 
     return node->u.object;
+}
+
+
+static njs_bool_t
+njs_generate_expr_requires_preservation_depth(njs_parser_node_t *node,
+    uint32_t depth)
+{
+    uint32_t                 i;
+    njs_bool_t               preserve;
+    njs_parser_array_item_t  *item;
+
+    if (node == NULL) {
+        return 0;
+    }
+
+    if (depth >= NJS_PRESERVATION_MAX_DEPTH) {
+        return 1;
+    }
+
+    if (node->token_type >= NJS_TOKEN_ASSIGNMENT
+        && node->token_type <= NJS_TOKEN_LAST_ASSIGNMENT)
+    {
+        return 1;
+    }
+
+    if (node->token_type == NJS_TOKEN_FUNCTION_CALL
+        || node->token_type == NJS_TOKEN_METHOD_CALL)
+    {
+        return 1;
+    }
+
+    if (node->token_type == NJS_TOKEN_ARRAY && node->u.array.items != NULL) {
+        for (i = 0; i < node->u.array.items->items; i++) {
+            item = njs_arr_item(node->u.array.items, i);
+
+            if (njs_generate_expr_requires_preservation_depth(item->value,
+                                                              depth + 1))
+            {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    preserve = njs_generate_expr_requires_preservation_depth(node->left,
+                                                             depth + 1);
+
+    if (njs_fast_path(!preserve)) {
+        return njs_generate_expr_requires_preservation_depth(node->right,
+                                                             depth + 1);
+    }
+
+    return preserve;
+}
+
+
+static njs_bool_t
+njs_generate_expr_requires_preservation(njs_parser_node_t *node)
+{
+    return njs_generate_expr_requires_preservation_depth(node, 0);
 }
 
 
@@ -3238,7 +3300,7 @@ njs_generate_preserve_property_lvalue(njs_vm_t *vm,
     njs_parser_node_t  *object, *property;
     njs_vmcode_move_t  *move;
 
-    if (!njs_slow_path(njs_parser_has_side_effect(expr))) {
+    if (!njs_slow_path(njs_generate_expr_requires_preservation(expr))) {
         return NJS_OK;
     }
 
@@ -3634,7 +3696,7 @@ njs_generate_operation_assignment(njs_vm_t *vm, njs_generator_t *generator,
         index = lvalue->index;
         expr = node->right;
 
-        if (njs_slow_path(njs_parser_has_side_effect(expr))) {
+        if (njs_slow_path(njs_generate_expr_requires_preservation(expr))) {
             /* Preserve variable value if it may be changed by expression. */
 
             njs_generate_code(generator, njs_vmcode_move_t, move,
@@ -4498,7 +4560,8 @@ njs_generate_3addr_operation_name(njs_vm_t *vm, njs_generator_t *generator,
 
     left = node->left;
 
-    if (njs_slow_path(njs_parser_has_side_effect(node->right))) {
+    if (njs_slow_path(njs_generate_expr_requires_preservation(node->right)))
+    {
         njs_generate_code(generator, njs_vmcode_move_t, move,
                           NJS_VMCODE_MOVE, node);
         move->src = left->index;

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -6360,7 +6360,9 @@ njs_generate_reference_error(njs_vm_t *vm, njs_generator_t *generator,
     njs_str_t           entry;
     njs_vmcode_error_t  *ref_err;
 
-    if (njs_slow_path(!node->u.reference.not_defined)) {
+    entry = njs_str_value("unknown");
+
+    if (njs_slow_path(!node->not_defined)) {
         njs_internal_error(vm, "variable is not defined but not_defined "
                                "is not set");
         return NJS_ERROR;

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -72,6 +72,12 @@ typedef struct {
 
 
 typedef struct {
+    njs_parser_node_t           *array;
+    uint32_t                    item;
+} njs_generator_array_ctx_t;
+
+
+typedef struct {
     njs_generator_patch_t       *patch;
     njs_generator_patch_t       **last;
     njs_vmcode_jump_t           *jump;
@@ -401,6 +407,8 @@ static njs_int_t njs_generate_property_accessor_end(njs_vm_t *vm,
     njs_generator_t *generator, njs_parser_node_t *node);
 static njs_int_t njs_generate_array(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node);
+static njs_int_t njs_generate_array_item(njs_vm_t *vm,
+    njs_generator_t *generator, njs_parser_node_t *node);
 static njs_int_t njs_generate_function_expression(njs_vm_t *vm,
     njs_generator_t *generator, njs_parser_node_t *node);
 static njs_int_t njs_generate_function(njs_vm_t *vm, njs_generator_t *generator,
@@ -3972,9 +3980,18 @@ static njs_int_t
 njs_generate_array(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_node_t *node)
 {
-    njs_vmcode_array_t  *array;
+    njs_int_t                  ret;
+    njs_parser_array_item_t    *item;
+    njs_vmcode_array_t         *array;
+    njs_generator_array_ctx_t  ctx;
 
-    node->index = njs_generate_object_dest_index(vm, generator, node);
+    if (node->u.array.items == NULL) {
+        node->index = njs_generate_object_dest_index(vm, generator, node);
+
+    } else {
+        node->index = njs_generate_node_temp_index_get(vm, generator, node);
+    }
+
     if (njs_slow_path(node->index == NJS_INDEX_ERROR)) {
         return NJS_ERROR;
     }
@@ -3982,16 +3999,66 @@ njs_generate_array(njs_vm_t *vm, njs_generator_t *generator,
     njs_generate_code(generator, njs_vmcode_array_t, array,
                       NJS_VMCODE_ARRAY, node);
     array->ctor = node->ctor;
+    array->flat = node->array_flat;
     array->retval = node->index;
-    array->length = node->u.length;
+    array->length = node->u.array.length;
 
-    /* Initialize array. */
+    if (node->u.array.items == NULL) {
+        return njs_generator_stack_pop(vm, generator, NULL);
+    }
 
-    njs_generator_next(generator, njs_generate, node->left);
+    ctx.array = node;
+    ctx.item = 0;
+    item = njs_arr_item(node->u.array.items, 0);
+
+    njs_generator_next(generator, njs_generate, item->value);
+
+    ret = njs_generator_after(vm, generator,
+                              njs_queue_first(&generator->stack), node,
+                              njs_generate_array_item, &ctx, sizeof(ctx));
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    return NJS_OK;
+}
+
+
+static njs_int_t
+njs_generate_array_item(njs_vm_t *vm, njs_generator_t *generator,
+    njs_parser_node_t *node)
+{
+    njs_int_t                  ret;
+    njs_parser_array_item_t    *item;
+    njs_vmcode_array_init_t    *init;
+    njs_generator_array_ctx_t  *ctx;
+
+    ctx = generator->context;
+    item = njs_arr_item(ctx->array->u.array.items, ctx->item);
+
+    njs_generate_code(generator, njs_vmcode_array_init_t, init,
+                      NJS_VMCODE_ARRAY_INIT, item->value);
+    init->value = item->value->index;
+    init->array = ctx->array->index;
+    init->index = item->index;
+
+    ret = njs_generate_node_index_release(vm, generator, item->value);
+    if (njs_slow_path(ret != NJS_OK)) {
+        return ret;
+    }
+
+    ctx->item++;
+
+    if (ctx->item == ctx->array->u.array.items->items) {
+        return njs_generator_stack_pop(vm, generator, ctx);
+    }
+
+    item = njs_arr_item(ctx->array->u.array.items, ctx->item);
+    njs_generator_next(generator, njs_generate, item->value);
 
     return njs_generator_after(vm, generator,
                                njs_queue_first(&generator->stack),
-                               NULL, njs_generator_pop, NULL, 0);
+                               node, njs_generate_array_item, ctx, 0);
 }
 
 

--- a/src/njs_generator.c
+++ b/src/njs_generator.c
@@ -5044,6 +5044,7 @@ njs_generate_scope(njs_vm_t *vm, njs_generator_t *generator,
     code->name = *name;
 
     generator->code_size = generator->code_end - generator->code_start;
+    scope->top = NULL;
 
     return code;
 }

--- a/src/njs_generator.h
+++ b/src/njs_generator.h
@@ -20,6 +20,7 @@ struct njs_generator_s {
     njs_queue_t                     stack;
     njs_parser_node_t               *node;
     void                            *context;
+    njs_mp_t                        *mem_pool;
 
     njs_value_t                     *local_scope;
 
@@ -41,8 +42,8 @@ struct njs_generator_s {
 };
 
 
-njs_int_t njs_generator_init(njs_generator_t *generator, njs_str_t *file,
-    njs_int_t depth, njs_bool_t runtime);
+njs_int_t njs_generator_init(njs_generator_t *generator, njs_mp_t *mem_pool,
+    njs_str_t *file, njs_int_t depth, njs_bool_t runtime);
 njs_vm_code_t *njs_generate_scope(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_scope_t *scope, const njs_str_t *name);
 njs_vm_code_t *njs_lookup_code(njs_vm_t *vm, u_char *pc);

--- a/src/njs_generator.h
+++ b/src/njs_generator.h
@@ -46,6 +46,7 @@ njs_int_t njs_generator_init(njs_generator_t *generator, njs_mp_t *mem_pool,
     njs_str_t *file, njs_int_t depth, njs_bool_t runtime);
 njs_vm_code_t *njs_generate_scope(njs_vm_t *vm, njs_generator_t *generator,
     njs_parser_scope_t *scope, const njs_str_t *name);
+void njs_generator_cleanup(njs_vm_t *vm, njs_uint_t code_index);
 njs_vm_code_t *njs_lookup_code(njs_vm_t *vm, u_char *pc);
 uint32_t njs_lookup_line(njs_arr_t *lines, uint32_t offset);
 

--- a/src/njs_lexer.c
+++ b/src/njs_lexer.c
@@ -293,14 +293,15 @@ static const njs_lexer_multi_t  njs_assignment_token[] = {
 
 
 njs_int_t
-njs_lexer_init(njs_vm_t *vm, njs_lexer_t *lexer, njs_str_t *file,
-    u_char *start, u_char *end)
+njs_lexer_init(njs_vm_t *vm, njs_mp_t *mem_pool, njs_lexer_t *lexer,
+    njs_str_t *file, u_char *start, u_char *end)
 {
     lexer->file = *file;
     lexer->start = start;
     lexer->end = end;
     lexer->line = 1;
     lexer->vm = vm;
+    lexer->mem_pool = mem_pool;
 
     njs_queue_init(&lexer->preread);
 
@@ -314,7 +315,7 @@ njs_lexer_next_token(njs_lexer_t *lexer)
     njs_int_t          ret;
     njs_lexer_token_t  *token;
 
-    token = njs_mp_zalloc(lexer->vm->mem_pool, sizeof(njs_lexer_token_t));
+    token = njs_mp_zalloc(lexer->mem_pool, sizeof(njs_lexer_token_t));
     if (njs_slow_path(token == NULL)) {
         return NULL;
     }
@@ -429,7 +430,7 @@ njs_lexer_consume_token(njs_lexer_t *lexer, unsigned length)
 
         njs_queue_remove(lnk);
 
-        njs_mp_free(lexer->vm->mem_pool, token);
+        njs_mp_free(lexer->mem_pool, token);
     }
 }
 

--- a/src/njs_lexer.h
+++ b/src/njs_lexer.h
@@ -263,14 +263,15 @@ typedef struct {
     njs_str_t                       file;
 
     njs_vm_t                        *vm;
+    njs_mp_t                        *mem_pool;
 
     u_char                          *start;
     u_char                          *end;
 } njs_lexer_t;
 
 
-njs_int_t njs_lexer_init(njs_vm_t *vm, njs_lexer_t *lexer, njs_str_t *file,
-    u_char *start, u_char *end);
+njs_int_t njs_lexer_init(njs_vm_t *vm, njs_mp_t *mem_pool,
+    njs_lexer_t *lexer, njs_str_t *file, u_char *start, u_char *end);
 
 njs_lexer_token_t *njs_lexer_token(njs_lexer_t *lexer,
     njs_bool_t with_end_line);

--- a/src/njs_module.c
+++ b/src/njs_module.c
@@ -139,6 +139,23 @@ njs_module_add(njs_vm_t *vm, njs_str_t *name, njs_value_t *value)
 }
 
 
+void
+njs_module_remove(njs_vm_t *vm, njs_mod_t *module)
+{
+    njs_flathsh_query_t  fhq;
+
+    fhq.key = module->name;
+    fhq.key_hash = njs_djb_hash(module->name.start, module->name.length);
+    fhq.pool = vm->mem_pool;
+    fhq.proto = &njs_modules_hash_proto;
+
+    (void) njs_flathsh_delete(&vm->shared->modules_hash, &fhq);
+
+    njs_mp_free(vm->mem_pool, module->name.start);
+    njs_mp_free(vm->mem_pool, module);
+}
+
+
 njs_int_t
 njs_module_require(njs_vm_t *vm, njs_value_t *args, njs_uint_t nargs,
     njs_index_t unused, njs_value_t *retval)

--- a/src/njs_module.h
+++ b/src/njs_module.h
@@ -16,6 +16,7 @@ struct njs_mod_s {
 
 
 njs_mod_t *njs_module_add(njs_vm_t *vm, njs_str_t *name, njs_value_t *value);
+void njs_module_remove(njs_vm_t *vm, njs_mod_t *module);
 njs_mod_t *njs_module_find(njs_vm_t *vm, njs_str_t *name,
     njs_bool_t shared);
 njs_int_t njs_module_require(njs_vm_t *vm, njs_value_t *args,

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -3696,10 +3696,6 @@ njs_parser_unary_expression_next(njs_parser_t *parser,
         }
     }
 
-    if (type == NJS_TOKEN_TYPEOF && node->token_type == NJS_TOKEN_NAME) {
-        node->u.reference.type = NJS_TYPEOF;
-    }
-
     parser->target->left = parser->node;
     parser->target->left->dest = parser->target;
     parser->node = parser->target;
@@ -8986,7 +8982,6 @@ njs_parser_variable_reference(njs_parser_t *parser, njs_parser_scope_t *scope,
     vr = &node->u.reference;
 
     vr->atom_id = atom_id;
-    vr->type = type;
 
     parse_node.key = atom_id;
 

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -549,6 +549,8 @@ njs_parser_init(njs_vm_t *vm, njs_parser_t *parser, njs_parser_scope_t *scope,
     lexer = &parser->lexer0;
     parser->lexer = lexer;
 
+    njs_rbtree_init(&parser->labels, njs_parser_scope_rbtree_compare);
+
     return njs_lexer_init(vm, lexer, file, start, end);
 }
 
@@ -672,7 +674,6 @@ njs_parser_scope_begin(njs_parser_t *parser, njs_scope_t type,
     scope->type = type;
 
     njs_rbtree_init(&scope->variables, njs_parser_scope_rbtree_compare);
-    njs_rbtree_init(&scope->labels, njs_parser_scope_rbtree_compare);
     njs_rbtree_init(&scope->references, njs_parser_scope_rbtree_compare);
 
     parent = parser->scope;
@@ -6036,8 +6037,7 @@ njs_parser_break_continue(njs_parser_t *parser, njs_lexer_token_t *token,
                 return njs_parser_stack_pop(parser);
             }
 
-            if (njs_label_find(parser->vm, parser->scope, token->atom_id)
-                == NULL)
+            if (!njs_label_find(parser, token->atom_id))
             {
                 njs_parser_syntax_error(parser, "Undefined label \"%V\"",
                                         &token->text);
@@ -6445,19 +6445,16 @@ njs_parser_labelled_statement(njs_parser_t *parser, njs_lexer_token_t *token,
     njs_queue_link_t *current)
 {
     uintptr_t       atom_id;
-    njs_variable_t  *label;
 
     atom_id = token->atom_id;
 
-    label = njs_label_find(parser->vm, parser->scope, atom_id);
-    if (label != NULL) {
+    if (njs_label_find(parser, atom_id)) {
         njs_parser_syntax_error(parser, "Label \"%V\" "
                                 "has already been declared", &token->text);
         return NJS_DONE;
     }
 
-    label = njs_label_add(parser->vm, parser->scope, atom_id);
-    if (label == NULL) {
+    if (njs_label_add(parser, atom_id) != NJS_OK) {
         return NJS_ERROR;
     }
 
@@ -6514,7 +6511,7 @@ njs_parser_labelled_statement_after(njs_parser_t *parser,
         return NJS_ERROR;
     }
 
-    ret = njs_label_remove(parser->vm, parser->scope, atom_id);
+    ret = njs_label_remove(parser, atom_id);
     if (ret != NJS_OK) {
         return NJS_ERROR;
     }
@@ -6917,7 +6914,7 @@ njs_parser_function_declaration_after(njs_parser_t *parser,
     njs_value_null_set(&parser->node->u.value);
 
     ret = njs_parser_variable_reference(parser, parser->scope, parser->node,
-                                        atom_id, NJS_DECLARATION);
+                                        atom_id);
     if (ret != NJS_OK) {
         return NJS_ERROR;
     }
@@ -6994,8 +6991,7 @@ njs_parser_function_expression(njs_parser_t *parser, njs_lexer_token_t *token,
     var->self = 1;
 
     ret = njs_parser_variable_reference(parser, parser->scope,
-                                        parser->node->left, atom_id,
-                                        NJS_DECLARATION);
+                                        parser->node->left, atom_id);
     if (ret != NJS_OK) {
         return NJS_ERROR;
     }
@@ -7224,7 +7220,7 @@ njs_parser_arrow_function(njs_parser_t *parser, njs_lexer_token_t *token,
     }
 
     ret = njs_parser_variable_reference(parser, parser->scope, node->left,
-                                        NJS_ATOM_STRING_empty, NJS_DECLARATION);
+                                        NJS_ATOM_STRING_empty);
     if (ret != NJS_OK) {
         return NJS_ERROR;
     }
@@ -8113,8 +8109,7 @@ njs_parser_variable_node(njs_parser_t *parser, uintptr_t atom_id,
         return NULL;
     }
 
-    ret = njs_parser_variable_reference(parser, parser->scope, node, atom_id,
-                                        NJS_DECLARATION);
+    ret = njs_parser_variable_reference(parser, parser->scope, node, atom_id);
     if (njs_slow_path(ret != NJS_OK)) {
         return NULL;
     }
@@ -8171,7 +8166,7 @@ njs_parser_reference(njs_parser_t *parser, njs_lexer_token_t *token)
         node->token_line = token->line;
 
         ret = njs_parser_variable_reference(parser, parser->scope, node,
-                                            token->atom_id, NJS_REFERENCE);
+                                            token->atom_id);
         if (njs_slow_path(ret != NJS_OK)) {
             return NULL;
         }
@@ -8196,7 +8191,7 @@ njs_parser_reference(njs_parser_t *parser, njs_lexer_token_t *token)
         node->token_line = token->line;
 
         ret = njs_parser_variable_reference(parser, parser->scope, node,
-                                            token->atom_id, NJS_REFERENCE);
+                                            token->atom_id);
         if (njs_slow_path(ret != NJS_OK)) {
             return NULL;
         }
@@ -8224,7 +8219,7 @@ njs_parser_reference(njs_parser_t *parser, njs_lexer_token_t *token)
             node->token_line = token->line;
 
             ret = njs_parser_variable_reference(parser, parser->scope, node,
-                                               token->atom_id, NJS_REFERENCE);
+                                                token->atom_id);
             if (njs_slow_path(ret != NJS_OK)) {
                 return NULL;
             }
@@ -8973,7 +8968,7 @@ njs_parser_has_side_effect(njs_parser_node_t *node)
 
 njs_int_t
 njs_parser_variable_reference(njs_parser_t *parser, njs_parser_scope_t *scope,
-    njs_parser_node_t *node, uintptr_t atom_id, njs_reference_type_t type)
+    njs_parser_node_t *node, uintptr_t atom_id)
 {
     njs_rbtree_node_t         *rb_node;
     njs_variable_reference_t  *vr;

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -8999,51 +8999,6 @@ invalid:
 }
 
 
-njs_bool_t
-njs_parser_has_side_effect(njs_parser_node_t *node)
-{
-    uint32_t                 i;
-    njs_bool_t               side_effect;
-    njs_parser_array_item_t  *item;
-
-    if (node == NULL) {
-        return 0;
-    }
-
-    if (node->token_type >= NJS_TOKEN_ASSIGNMENT
-        && node->token_type <= NJS_TOKEN_LAST_ASSIGNMENT)
-    {
-        return 1;
-    }
-
-    if (node->token_type == NJS_TOKEN_FUNCTION_CALL
-        || node->token_type == NJS_TOKEN_METHOD_CALL)
-    {
-        return 1;
-    }
-
-    if (node->token_type == NJS_TOKEN_ARRAY && node->u.array.items != NULL) {
-        for (i = 0; i < node->u.array.items->items; i++) {
-            item = njs_arr_item(node->u.array.items, i);
-
-            if (njs_parser_has_side_effect(item->value)) {
-                return 1;
-            }
-        }
-
-        return 0;
-    }
-
-    side_effect = njs_parser_has_side_effect(node->left);
-
-    if (njs_fast_path(!side_effect)) {
-        return njs_parser_has_side_effect(node->right);
-    }
-
-    return side_effect;
-}
-
-
 njs_int_t
 njs_parser_variable_reference(njs_parser_t *parser, njs_parser_scope_t *scope,
     njs_parser_node_t *node, uintptr_t atom_id)

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -1336,6 +1336,7 @@ njs_parser_template_literal(njs_parser_t *parser, njs_lexer_token_t *token,
     }
 
     array->token_line = token->line;
+    array->array_flat = 1;
 
     template = parser->node;
 
@@ -1517,7 +1518,7 @@ njs_parser_array_element_list(njs_parser_t *parser, njs_lexer_token_t *token,
         njs_lexer_consume_token(parser->lexer, 1);
 
         array->ctor = 1;
-        array->u.length++;
+        array->u.array.length++;
 
         return NJS_OK;
 
@@ -8250,8 +8251,7 @@ njs_parser_object_value(njs_parser_t *parser, njs_parser_node_t *parent,
 {
     njs_parser_node_t  *object;
 
-    njs_assert(parent->token_type == NJS_TOKEN_OBJECT
-               || parent->token_type == NJS_TOKEN_ARRAY);
+    njs_assert(parent->token_type == NJS_TOKEN_OBJECT);
 
     object = njs_parser_node_new(parser, NJS_TOKEN_OBJECT_VALUE);
     if (njs_slow_path(object == NULL)) {
@@ -8379,25 +8379,31 @@ static njs_int_t
 njs_parser_array_item(njs_parser_t *parser, njs_parser_node_t *array,
     njs_parser_node_t *value)
 {
-    njs_int_t          ret;
-    njs_parser_node_t  *number;
+    njs_arr_t                *items;
+    njs_parser_array_item_t  *item;
 
-    number = njs_parser_node_new(parser, NJS_TOKEN_NUMBER);
-    if (njs_slow_path(number == NULL)) {
+    items = array->u.array.items;
+
+    if (items == NULL) {
+        items = njs_arr_create(parser->vm->mem_pool, 4,
+                               sizeof(njs_parser_array_item_t));
+        if (njs_slow_path(items == NULL)) {
+            return NJS_ERROR;
+        }
+
+        array->u.array.items = items;
+    }
+
+    item = njs_arr_add(items);
+    if (njs_slow_path(item == NULL)) {
         return NJS_ERROR;
     }
 
-    njs_set_number(&number->u.value, array->u.length);
-
-    number->token_line = value->token_line;
-
-    ret = njs_parser_object_property(parser, array, number, value, 0);
-    if (njs_slow_path(ret != NJS_OK)) {
-        return NJS_ERROR;
-    }
+    item->value = value;
+    item->index = array->u.array.length;
 
     array->ctor = 0;
-    array->u.length++;
+    array->u.array.length++;
 
     return NJS_OK;
 }
@@ -8927,7 +8933,9 @@ invalid:
 njs_bool_t
 njs_parser_has_side_effect(njs_parser_node_t *node)
 {
-    njs_bool_t  side_effect;
+    uint32_t                 i;
+    njs_bool_t               side_effect;
+    njs_parser_array_item_t  *item;
 
     if (node == NULL) {
         return 0;
@@ -8943,6 +8951,18 @@ njs_parser_has_side_effect(njs_parser_node_t *node)
         || node->token_type == NJS_TOKEN_METHOD_CALL)
     {
         return 1;
+    }
+
+    if (node->token_type == NJS_TOKEN_ARRAY && node->u.array.items != NULL) {
+        for (i = 0; i < node->u.array.items->items; i++) {
+            item = njs_arr_item(node->u.array.items, i);
+
+            if (njs_parser_has_side_effect(item->value)) {
+                return 1;
+            }
+        }
+
+        return 0;
     }
 
     side_effect = njs_parser_has_side_effect(node->left);
@@ -9065,9 +9085,11 @@ njs_int_t
 njs_parser_traverse(njs_vm_t *vm, njs_parser_node_t *root, void *ctx,
     njs_parser_traverse_cb_t cb)
 {
-    njs_int_t          ret;
-    njs_arr_t          *stack;
-    njs_parser_node_t  *node, **ref;
+    uint32_t                 i;
+    njs_int_t                ret;
+    njs_arr_t                *stack;
+    njs_parser_node_t        *node, **ref;
+    njs_parser_array_item_t  *item;
 
     if (root == NULL) {
         return NJS_OK;
@@ -9097,6 +9119,22 @@ njs_parser_traverse(njs_vm_t *vm, njs_parser_node_t *root, void *ctx,
         ret = cb(vm, node, ctx);
         if (njs_slow_path(ret != NJS_OK)) {
             goto failed;
+        }
+
+        if (node->token_type == NJS_TOKEN_ARRAY
+            && node->u.array.items != NULL)
+        {
+            i = node->u.array.items->items;
+
+            while (i != 0) {
+                item = njs_arr_item(node->u.array.items, --i);
+                ref = njs_arr_add(stack);
+                if (njs_slow_path(ref == NULL)) {
+                    goto failed;
+                }
+
+                *ref = item->value;
+            }
         }
 
         if (node->left != NULL) {
@@ -9159,7 +9197,9 @@ static void
 njs_parser_serialize_tree(njs_chb_t *chain, njs_parser_node_t *node,
     njs_int_t *ret, size_t indent)
 {
-    njs_str_t  str;
+    uint32_t                 i;
+    njs_str_t                str;
+    njs_parser_array_item_t  *item;
 
     njs_chb_append_literal(chain, "{\"name\": \"");
 
@@ -9205,6 +9245,24 @@ njs_parser_serialize_tree(njs_chb_t *chain, njs_parser_node_t *node,
 
     default:
         break;
+    }
+
+    if (node->token_type == NJS_TOKEN_ARRAY && node->u.array.items != NULL) {
+        njs_chb_append_literal(chain, ",\n");
+        njs_parser_serialize_indent(chain, indent);
+        njs_chb_append_literal(chain, " \"items\": [");
+
+        for (i = 0; i < node->u.array.items->items; i++) {
+            item = njs_arr_item(node->u.array.items, i);
+
+            if (i != 0) {
+                njs_chb_append_literal(chain, ", ");
+            }
+
+            njs_parser_serialize_tree(chain, item->value, ret, indent + 1);
+        }
+
+        njs_chb_append_literal(chain, "]");
     }
 
     if (node->left != NULL) {

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -9112,8 +9112,8 @@ njs_parser_node_error(njs_vm_t *vm, njs_object_type_t type,
 
 
 njs_int_t
-njs_parser_traverse(njs_vm_t *vm, njs_parser_node_t *root, void *ctx,
-    njs_parser_traverse_cb_t cb)
+njs_parser_traverse(njs_vm_t *vm, njs_mp_t *mem_pool, njs_parser_node_t *root,
+    void *ctx, njs_parser_traverse_cb_t cb)
 {
     uint32_t                 i;
     njs_int_t                ret;
@@ -9125,7 +9125,7 @@ njs_parser_traverse(njs_vm_t *vm, njs_parser_node_t *root, void *ctx,
         return NJS_OK;
     }
 
-    stack = njs_arr_create(vm->mem_pool, 8, sizeof(njs_parser_node_t *));
+    stack = njs_arr_create(mem_pool, 8, sizeof(njs_parser_node_t *));
     if (njs_slow_path(stack == NULL)) {
         return NJS_ERROR;
 

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -540,7 +540,7 @@ njs_parser_reject(njs_parser_t *parser)
 
 njs_int_t
 njs_parser_init(njs_vm_t *vm, njs_parser_t *parser, njs_parser_scope_t *scope,
-    njs_str_t *file, u_char *start, u_char *end)
+    njs_bool_t persistent_global, njs_str_t *file, u_char *start, u_char *end)
 {
     njs_int_t    ret;
     njs_lexer_t  *lexer;
@@ -548,6 +548,8 @@ njs_parser_init(njs_vm_t *vm, njs_parser_t *parser, njs_parser_scope_t *scope,
     njs_memzero(parser, sizeof(njs_parser_t));
 
     parser->scope = scope;
+    parser->persistent_scope = scope;
+    parser->persistent_global = persistent_global;
 
     parser->mem_pool = njs_mp_fast_create(2 * njs_pagesize(), 128, 512, 16);
     if (njs_slow_path(parser->mem_pool == NULL)) {
@@ -573,10 +575,36 @@ njs_parser_init(njs_vm_t *vm, njs_parser_t *parser, njs_parser_scope_t *scope,
 void
 njs_parser_destroy(njs_parser_t *parser)
 {
-    njs_parser_scope_t  *scope;
+    njs_variable_t       *var;
+    njs_rbtree_node_t    *node;
+    njs_parser_scope_t   *scope;
+    njs_variable_node_t  *var_node;
 
     for (scope = parser->scope; scope != NULL; scope = scope->parent) {
         scope->top = NULL;
+    }
+
+    if (parser->persistent_scope != NULL) {
+        node = njs_rbtree_min(&parser->persistent_scope->variables);
+
+        while (njs_rbtree_is_there_successor(
+                   &parser->persistent_scope->variables, node))
+        {
+            var_node = (njs_variable_node_t *) node;
+            var = var_node->variable;
+
+            if (var->original != parser->persistent_scope) {
+                var->original = NULL;
+            }
+
+            node = njs_rbtree_node_successor(
+                       &parser->persistent_scope->variables, node);
+        }
+
+        njs_rbtree_init(&parser->persistent_scope->references,
+                        njs_parser_scope_rbtree_compare);
+        parser->persistent_scope->closures = NULL;
+        parser->persistent_scope->declarations = NULL;
     }
 
     if (parser->mem_pool != NULL) {
@@ -697,7 +725,13 @@ njs_parser_scope_begin(njs_parser_t *parser, njs_scope_t type,
     njs_variable_t      *var;
     njs_parser_scope_t  *scope, *parent;
 
-    scope = njs_mp_zalloc(parser->vm->mem_pool, sizeof(njs_parser_scope_t));
+    if (parser->scope == NULL && parser->persistent_global) {
+        scope = njs_mp_zalloc(parser->vm->mem_pool,
+                              sizeof(njs_parser_scope_t));
+
+    } else {
+        scope = njs_mp_zalloc(parser->mem_pool, sizeof(njs_parser_scope_t));
+    }
     if (njs_slow_path(scope == NULL)) {
         return NJS_ERROR;
     }
@@ -710,6 +744,10 @@ njs_parser_scope_begin(njs_parser_t *parser, njs_scope_t type,
     parent = parser->scope;
     scope->parent = parent;
     parser->scope = scope;
+
+    if (parent == NULL && parser->persistent_global) {
+        parser->persistent_scope = scope;
+    }
 
     if (type == NJS_SCOPE_FUNCTION || type == NJS_SCOPE_GLOBAL) {
         if (init_this) {
@@ -9025,7 +9063,7 @@ njs_parser_variable_reference(njs_parser_t *parser, njs_parser_scope_t *scope,
         return NJS_OK;
     }
 
-    rb_parse_node = njs_mp_alloc(parser->vm->mem_pool,
+    rb_parse_node = njs_mp_alloc(parser->mem_pool,
                                  sizeof(njs_parser_rbtree_node_t));
     if (njs_slow_path(rb_parse_node == NULL)) {
         return NJS_ERROR;

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -381,6 +381,8 @@ static njs_int_t njs_parser_labelled_statement(njs_parser_t *parser,
     njs_lexer_token_t *token, njs_queue_link_t *current);
 static njs_int_t njs_parser_labelled_statement_after(njs_parser_t *parser,
     njs_lexer_token_t *token, njs_queue_link_t *current);
+static void njs_parser_statement_label(njs_parser_node_t *node,
+    uintptr_t atom_id);
 
 static njs_int_t njs_parser_throw_statement(njs_parser_t *parser,
     njs_lexer_token_t *token, njs_queue_link_t *current);
@@ -6015,8 +6017,6 @@ static njs_int_t
 njs_parser_break_continue(njs_parser_t *parser, njs_lexer_token_t *token,
     njs_token_type_t type)
 {
-    njs_int_t  ret;
-
     parser->node = njs_parser_node_new(parser, type);
     if (parser->node == NULL) {
         return NJS_ERROR;
@@ -6044,10 +6044,7 @@ njs_parser_break_continue(njs_parser_t *parser, njs_lexer_token_t *token,
                 return NJS_DONE;
             }
 
-            ret = njs_name_copy(parser->vm, &parser->node->name, &token->text);
-            if (ret != NJS_OK) {
-                return NJS_ERROR;
-            }
+            parser->node->u.label = token->atom_id;
 
             break;
         }
@@ -6486,7 +6483,6 @@ njs_parser_labelled_statement_after(njs_parser_t *parser,
     njs_lexer_token_t *token, njs_queue_link_t *current)
 {
     njs_int_t          ret;
-    njs_str_t          str;
     uintptr_t          atom_id;
     njs_parser_node_t  *node;
 
@@ -6504,12 +6500,7 @@ njs_parser_labelled_statement_after(njs_parser_t *parser,
 
     atom_id = (uint32_t) (uintptr_t) parser->target;
 
-    njs_atom_string_get(parser->vm, atom_id, &str);
-
-    ret = njs_name_copy(parser->vm, &parser->node->name, &str);
-    if (ret != NJS_OK) {
-        return NJS_ERROR;
-    }
+    njs_parser_statement_label(parser->node, atom_id);
 
     ret = njs_label_remove(parser, atom_id);
     if (ret != NJS_OK) {
@@ -6517,6 +6508,26 @@ njs_parser_labelled_statement_after(njs_parser_t *parser,
     }
 
     return njs_parser_stack_pop(parser);
+}
+
+
+static void
+njs_parser_statement_label(njs_parser_node_t *node, uintptr_t atom_id)
+{
+    switch (node->token_type) {
+    case NJS_TOKEN_BLOCK:
+    case NJS_TOKEN_IF:
+    case NJS_TOKEN_SWITCH:
+    case NJS_TOKEN_WHILE:
+    case NJS_TOKEN_DO:
+    case NJS_TOKEN_FOR:
+    case NJS_TOKEN_FOR_IN:
+        node->u.label = atom_id;
+        break;
+
+    default:
+        break;
+    }
 }
 
 

--- a/src/njs_parser.c
+++ b/src/njs_parser.c
@@ -542,18 +542,47 @@ njs_int_t
 njs_parser_init(njs_vm_t *vm, njs_parser_t *parser, njs_parser_scope_t *scope,
     njs_str_t *file, u_char *start, u_char *end)
 {
+    njs_int_t    ret;
     njs_lexer_t  *lexer;
 
     njs_memzero(parser, sizeof(njs_parser_t));
 
     parser->scope = scope;
 
+    parser->mem_pool = njs_mp_fast_create(2 * njs_pagesize(), 128, 512, 16);
+    if (njs_slow_path(parser->mem_pool == NULL)) {
+        njs_memory_error(vm);
+        return NJS_ERROR;
+    }
+
     lexer = &parser->lexer0;
     parser->lexer = lexer;
 
     njs_rbtree_init(&parser->labels, njs_parser_scope_rbtree_compare);
 
-    return njs_lexer_init(vm, lexer, file, start, end);
+    ret = njs_lexer_init(vm, parser->mem_pool, lexer, file, start, end);
+    if (njs_slow_path(ret != NJS_OK)) {
+        njs_mp_destroy(parser->mem_pool);
+        parser->mem_pool = NULL;
+    }
+
+    return ret;
+}
+
+
+void
+njs_parser_destroy(njs_parser_t *parser)
+{
+    njs_parser_scope_t  *scope;
+
+    for (scope = parser->scope; scope != NULL; scope = scope->parent) {
+        scope->top = NULL;
+    }
+
+    if (parser->mem_pool != NULL) {
+        njs_mp_destroy(parser->mem_pool);
+        parser->mem_pool = NULL;
+    }
 }
 
 
@@ -8387,7 +8416,7 @@ njs_parser_array_item(njs_parser_t *parser, njs_parser_node_t *array,
     items = array->u.array.items;
 
     if (items == NULL) {
-        items = njs_arr_create(parser->vm->mem_pool, 4,
+        items = njs_arr_create(parser->mem_pool, 4,
                                sizeof(njs_parser_array_item_t));
         if (njs_slow_path(items == NULL)) {
             return NJS_ERROR;

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -94,6 +94,7 @@ struct njs_parser_s {
     njs_parser_node_t               *node;
     njs_parser_node_t               *target;
     njs_parser_scope_t              *scope;
+    njs_parser_scope_t              *persistent_scope;
     njs_rbtree_t                    labels;
     njs_variable_type_t             var_type;
     njs_int_t                       ret;
@@ -102,6 +103,7 @@ struct njs_parser_s {
     uint8_t                         allow_in;
 
     uint8_t                         module;
+    uint8_t                         persistent_global;
 
     njs_str_t                       file;
     uint32_t                        line;
@@ -144,7 +146,8 @@ njs_int_t njs_parser_failed_state(njs_parser_t *parser,
 intptr_t njs_parser_scope_rbtree_compare(njs_rbtree_node_t *node1,
     njs_rbtree_node_t *node2);
 njs_int_t njs_parser_init(njs_vm_t *vm, njs_parser_t *parser,
-    njs_parser_scope_t *scope, njs_str_t *file, u_char *start, u_char *end);
+    njs_parser_scope_t *scope, njs_bool_t persistent_global, njs_str_t *file,
+    u_char *start, u_char *end);
 void njs_parser_destroy(njs_parser_t *parser);
 njs_int_t njs_parser(njs_vm_t *vm, njs_parser_t *parser);
 

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -14,7 +14,6 @@ struct njs_parser_scope_s {
 
     njs_parser_scope_t              *parent;
     njs_rbtree_t                    variables;
-    njs_rbtree_t                    labels;
     njs_rbtree_t                    references;
 
     njs_arr_t                       *closures;
@@ -33,6 +32,14 @@ typedef struct {
     njs_parser_node_t               *value;
     uint32_t                        index;
 } njs_parser_array_item_t;
+
+
+typedef struct njs_parser_label_s  njs_parser_label_t;
+
+struct njs_parser_label_s {
+    NJS_RBTREE_NODE                 (node);
+    uintptr_t                       key;
+};
 
 
 struct njs_parser_node_s {
@@ -87,6 +94,7 @@ struct njs_parser_s {
     njs_parser_node_t               *node;
     njs_parser_node_t               *target;
     njs_parser_scope_t              *scope;
+    njs_rbtree_t                    labels;
     njs_variable_type_t             var_type;
     njs_int_t                       ret;
 
@@ -145,8 +153,7 @@ njs_variable_t *njs_variable_resolve(njs_vm_t *vm, njs_parser_node_t *node);
 njs_index_t njs_variable_index(njs_vm_t *vm, njs_parser_node_t *node);
 njs_bool_t njs_parser_has_side_effect(njs_parser_node_t *node);
 njs_int_t njs_parser_variable_reference(njs_parser_t *parser,
-    njs_parser_scope_t *scope, njs_parser_node_t *node, uintptr_t atom_id,
-    njs_reference_type_t type);
+    njs_parser_scope_t *scope, njs_parser_node_t *node, uintptr_t atom_id);
 njs_token_type_t njs_parser_unexpected_token(njs_vm_t *vm, njs_parser_t *parser,
     njs_str_t *name, njs_token_type_t type);
 njs_int_t njs_parser_string_create(njs_vm_t *vm, njs_lexer_token_t *token,

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -90,6 +90,7 @@ struct njs_parser_s {
     njs_lexer_t                     lexer0;
     njs_lexer_t                     *lexer;
     njs_vm_t                        *vm;
+    njs_mp_t                        *mem_pool;
     njs_parser_node_t               *node;
     njs_parser_node_t               *target;
     njs_parser_scope_t              *scope;
@@ -144,6 +145,7 @@ intptr_t njs_parser_scope_rbtree_compare(njs_rbtree_node_t *node1,
     njs_rbtree_node_t *node2);
 njs_int_t njs_parser_init(njs_vm_t *vm, njs_parser_t *parser,
     njs_parser_scope_t *scope, njs_str_t *file, u_char *start, u_char *end);
+void njs_parser_destroy(njs_parser_t *parser);
 njs_int_t njs_parser(njs_vm_t *vm, njs_parser_t *parser);
 
 njs_bool_t njs_variable_closure_test(njs_parser_scope_t *root,
@@ -205,7 +207,7 @@ njs_parser_node_new(njs_parser_t *parser, njs_token_type_t type)
 {
     njs_parser_node_t  *node;
 
-    node = njs_mp_zalloc(parser->vm->mem_pool, sizeof(njs_parser_node_t));
+    node = njs_mp_zalloc(parser->mem_pool, sizeof(njs_parser_node_t));
 
     if (njs_fast_path(node != NULL)) {
         node->token_type = type;
@@ -219,7 +221,7 @@ njs_parser_node_new(njs_parser_t *parser, njs_token_type_t type)
 njs_inline void
 njs_parser_node_free(njs_parser_t *parser, njs_parser_node_t *node)
 {
-    njs_mp_free(parser->vm->mem_pool, node);
+    njs_mp_free(parser->mem_pool, node);
 }
 
 
@@ -332,7 +334,7 @@ njs_parser_stack_pop(njs_parser_t *parser)
     parser->allow_in = entry->allow_in;
     parser->var_type = entry->var_type;
 
-    njs_mp_free(parser->vm->mem_pool, entry);
+    njs_mp_free(parser->mem_pool, entry);
 
     return NJS_OK;
 }
@@ -367,8 +369,7 @@ _njs_parser_after(njs_parser_t *parser, njs_queue_link_t *link, void *node,
 {
     njs_parser_stack_entry_t  *entry;
 
-    entry = njs_mp_alloc(parser->vm->mem_pool,
-                         sizeof(njs_parser_stack_entry_t));
+    entry = njs_mp_alloc(parser->mem_pool, sizeof(njs_parser_stack_entry_t));
     if (njs_slow_path(entry == NULL)) {
         return NJS_ERROR;
     }

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -29,15 +29,25 @@ struct njs_parser_scope_s {
 };
 
 
+typedef struct {
+    njs_parser_node_t               *value;
+    uint32_t                        index;
+} njs_parser_array_item_t;
+
+
 struct njs_parser_node_s {
     njs_token_type_t                token_type:16;
     uint8_t                         ctor:1;
     uint8_t                         hoist:1;
+    uint8_t                         array_flat:1;
     uint8_t                         temporary;    /* 1 bit  */
     uint32_t                        token_line;
 
     union {
-        uint32_t                    length;
+        struct {
+            njs_arr_t               *items;
+            uint32_t                length;
+        } array;
         njs_variable_reference_t    reference;
         njs_value_t                 value;
         njs_vmcode_t                operation;

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -155,7 +155,6 @@ njs_bool_t njs_variable_closure_test(njs_parser_scope_t *root,
     njs_parser_scope_t *scope);
 njs_variable_t *njs_variable_resolve(njs_vm_t *vm, njs_parser_node_t *node);
 njs_index_t njs_variable_index(njs_vm_t *vm, njs_parser_node_t *node);
-njs_bool_t njs_parser_has_side_effect(njs_parser_node_t *node);
 njs_int_t njs_parser_variable_reference(njs_parser_t *parser,
     njs_parser_scope_t *scope, njs_parser_node_t *node, uintptr_t atom_id);
 njs_token_type_t njs_parser_unexpected_token(njs_vm_t *vm, njs_parser_t *parser,

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -58,12 +58,11 @@ struct njs_parser_node_s {
         } array;
         njs_variable_reference_t    reference;
         njs_value_t                 value;
+        uintptr_t                   label;
         njs_vmcode_t                operation;
         njs_parser_node_t           *object;
         njs_mod_t                   *module;
     } u;
-
-    njs_str_t                       name;
 
     njs_index_t                     index;
 

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -164,8 +164,8 @@ void njs_parser_lexer_error(njs_parser_t *parser,
 void njs_parser_node_error(njs_vm_t *vm, njs_object_type_t type,
     njs_parser_node_t *node, njs_str_t *file, const char *fmt, ...);
 
-njs_int_t njs_parser_traverse(njs_vm_t *vm, njs_parser_node_t *root,
-    void *ctx, njs_parser_traverse_cb_t cb);
+njs_int_t njs_parser_traverse(njs_vm_t *vm, njs_mp_t *mem_pool,
+    njs_parser_node_t *root, void *ctx, njs_parser_traverse_cb_t cb);
 njs_int_t njs_parser_serialize_ast(njs_parser_node_t *node, njs_chb_t *chain);
 
 

--- a/src/njs_parser.h
+++ b/src/njs_parser.h
@@ -40,6 +40,7 @@ struct njs_parser_node_s {
     uint8_t                         ctor:1;
     uint8_t                         hoist:1;
     uint8_t                         array_flat:1;
+    uint8_t                         not_defined:1;
     uint8_t                         temporary;    /* 1 bit  */
     uint32_t                        token_line;
 

--- a/src/njs_variable.c
+++ b/src/njs_variable.c
@@ -306,7 +306,7 @@ njs_label_add(njs_parser_t *parser, uintptr_t atom_id)
 {
     njs_parser_label_t  *label;
 
-    label = njs_mp_alloc(parser->vm->mem_pool, sizeof(njs_parser_label_t));
+    label = njs_mp_alloc(parser->mem_pool, sizeof(njs_parser_label_t));
     if (njs_slow_path(label == NULL)) {
         njs_memory_error(parser->vm);
         return NJS_ERROR;
@@ -335,7 +335,7 @@ njs_label_remove(njs_parser_t *parser, uintptr_t atom_id)
     }
 
     njs_rbtree_delete(&parser->labels, (njs_rbtree_part_t *) node);
-    njs_mp_free(parser->vm->mem_pool, node);
+    njs_mp_free(parser->mem_pool, node);
 
     return NJS_OK;
 }

--- a/src/njs_variable.c
+++ b/src/njs_variable.c
@@ -13,8 +13,8 @@ static njs_declaration_t *njs_variable_scope_function_add(njs_parser_t *parser,
     njs_parser_scope_t *scope);
 static njs_parser_scope_t *njs_variable_scope_find(njs_parser_t *parser,
      njs_parser_scope_t *scope, uintptr_t atom_id, njs_variable_type_t type);
-static njs_variable_t *njs_variable_alloc(njs_vm_t *vm, uintptr_t atom_id,
-    njs_variable_type_t type);
+static njs_variable_t *njs_variable_alloc(njs_vm_t *vm, njs_mp_t *mem_pool,
+    uintptr_t atom_id, njs_variable_type_t type);
 
 
 njs_variable_t *
@@ -96,7 +96,7 @@ static njs_declaration_t *
 njs_variable_scope_function_add(njs_parser_t *parser, njs_parser_scope_t *scope)
 {
     if (scope->declarations == NULL) {
-        scope->declarations = njs_arr_create(parser->vm->mem_pool, 1,
+        scope->declarations = njs_arr_create(parser->mem_pool, 1,
                                              sizeof(njs_declaration_t));
         if (njs_slow_path(scope->declarations == NULL)) {
             return NULL;
@@ -202,11 +202,11 @@ njs_variable_scope_find(njs_parser_t *parser, njs_parser_scope_t *scope,
         goto failed;
     }
 
-    if (var->original->type == NJS_SCOPE_BLOCK) {
+    if (var->original_type == NJS_SCOPE_BLOCK) {
         if (type == NJS_VARIABLE_FUNCTION
             || var->type == NJS_VARIABLE_FUNCTION)
         {
-            if (var->original == root) {
+            if (var->original != NULL && var->original == root) {
                 goto failed;
             }
         }
@@ -251,6 +251,7 @@ njs_variable_scope_add(njs_parser_t *parser, njs_parser_scope_t *scope,
     njs_parser_scope_t *original, uintptr_t atom_id,
     njs_variable_type_t type, njs_index_t index)
 {
+    njs_mp_t             *mem_pool;
     njs_variable_t       *var;
     njs_rbtree_node_t    *node;
     njs_parser_scope_t   *root;
@@ -264,7 +265,10 @@ njs_variable_scope_add(njs_parser_t *parser, njs_parser_scope_t *scope,
         return ((njs_variable_node_t *) node)->variable;
     }
 
-    var = njs_variable_alloc(parser->vm, atom_id, type);
+    mem_pool = (scope == parser->persistent_scope) ? parser->vm->mem_pool
+                                                   : parser->mem_pool;
+
+    var = njs_variable_alloc(parser->vm, mem_pool, atom_id, type);
     if (njs_slow_path(var == NULL)) {
         goto memory_error;
     }
@@ -272,6 +276,7 @@ njs_variable_scope_add(njs_parser_t *parser, njs_parser_scope_t *scope,
     var->scope = scope;
     var->index = index;
     var->original = original;
+    var->original_type = original->type;
 
     if (index == NJS_INDEX_NONE) {
         root = njs_function_scope(scope);
@@ -284,7 +289,7 @@ njs_variable_scope_add(njs_parser_t *parser, njs_parser_scope_t *scope,
         root->items++;
     }
 
-    var_node_new = njs_variable_node_alloc(parser->vm, var, atom_id);
+    var_node_new = njs_variable_node_alloc(mem_pool, var, atom_id);
     if (njs_slow_path(var_node_new == NULL)) {
         goto memory_error;
     }
@@ -390,7 +395,7 @@ njs_variable_resolve(njs_vm_t *vm, njs_parser_node_t *node)
 
 
 static njs_index_t
-njs_variable_closure(njs_vm_t *vm, njs_variable_t *var,
+njs_variable_closure(njs_vm_t *vm, njs_mp_t *mem_pool, njs_variable_t *var,
     njs_parser_scope_t *scope)
 {
     njs_index_t               index, prev_index, *idx;
@@ -460,7 +465,7 @@ njs_variable_closure(njs_vm_t *vm, njs_variable_t *var,
             if (parse_node == NULL) {
                 /* Create new reference for closure. */
 
-                parse_node = njs_mp_alloc(vm->mem_pool,
+                parse_node = njs_mp_alloc(mem_pool,
                                           sizeof(njs_parser_rbtree_node_t));
                 if (njs_slow_path(parse_node == NULL)) {
                     return NJS_INDEX_ERROR;
@@ -482,7 +487,8 @@ njs_variable_closure(njs_vm_t *vm, njs_variable_t *var,
 
 
 njs_variable_t *
-njs_variable_reference(njs_vm_t *vm, njs_parser_node_t *node)
+njs_variable_reference(njs_vm_t *vm, njs_mp_t *mem_pool,
+    njs_parser_node_t *node)
 {
     njs_bool_t                closure;
     njs_rbtree_node_t         *rb_node;
@@ -527,7 +533,7 @@ njs_variable_reference(njs_vm_t *vm, njs_parser_node_t *node)
 
     ref->variable->closure = closure;
 
-    node->index = njs_variable_closure(vm, ref->variable, scope);
+    node->index = njs_variable_closure(vm, mem_pool, ref->variable, scope);
     if (njs_slow_path(node->index == NJS_INDEX_ERROR)) {
         return NULL;
     }
@@ -548,11 +554,12 @@ njs_label_find(njs_parser_t *parser, uintptr_t atom_id)
 
 
 static njs_variable_t *
-njs_variable_alloc(njs_vm_t *vm, uintptr_t atom_id, njs_variable_type_t type)
+njs_variable_alloc(njs_vm_t *vm, njs_mp_t *mem_pool, uintptr_t atom_id,
+    njs_variable_type_t type)
 {
     njs_variable_t  *var;
 
-    var = njs_mp_zalloc(vm->mem_pool, sizeof(njs_variable_t));
+    var = njs_mp_zalloc(mem_pool, sizeof(njs_variable_t));
     if (njs_slow_path(var == NULL)) {
         njs_memory_error(vm);
         return NULL;

--- a/src/njs_variable.c
+++ b/src/njs_variable.c
@@ -301,59 +301,41 @@ memory_error:
 }
 
 
-njs_variable_t *
-njs_label_add(njs_vm_t *vm, njs_parser_scope_t *scope, uintptr_t atom_id)
+njs_int_t
+njs_label_add(njs_parser_t *parser, uintptr_t atom_id)
 {
-    njs_variable_t       *label;
-    njs_rbtree_node_t    *node;
-    njs_variable_node_t  var_node, *var_node_new;
+    njs_parser_label_t  *label;
 
-    var_node.key = atom_id;
-
-    node = njs_rbtree_find(&scope->labels, &var_node.node);
-
-    if (node != NULL) {
-        return ((njs_variable_node_t *) node)->variable;
-    }
-
-    label = njs_variable_alloc(vm, atom_id, NJS_VARIABLE_CONST);
+    label = njs_mp_alloc(parser->vm->mem_pool, sizeof(njs_parser_label_t));
     if (njs_slow_path(label == NULL)) {
-        goto memory_error;
+        njs_memory_error(parser->vm);
+        return NJS_ERROR;
     }
 
-    var_node_new = njs_variable_node_alloc(vm, label, atom_id);
-    if (njs_slow_path(var_node_new == NULL)) {
-        goto memory_error;
-    }
+    label->key = atom_id;
 
-    njs_rbtree_insert(&scope->labels, &var_node_new->node);
+    njs_rbtree_insert(&parser->labels, &label->node);
 
-    return label;
-
-memory_error:
-
-    njs_memory_error(vm);
-
-    return NULL;
+    return NJS_OK;
 }
 
 
 njs_int_t
-njs_label_remove(njs_vm_t *vm, njs_parser_scope_t *scope, uintptr_t atom_id)
+njs_label_remove(njs_parser_t *parser, uintptr_t atom_id)
 {
-    njs_rbtree_node_t    *node;
-    njs_variable_node_t  var_node;
+    njs_rbtree_node_t   *node;
+    njs_parser_label_t  label;
 
-    var_node.key = atom_id;
+    label.key = atom_id;
 
-    node = njs_rbtree_find(&scope->labels, &var_node.node);
+    node = njs_rbtree_find(&parser->labels, &label.node);
     if (njs_slow_path(node == NULL)) {
-        njs_internal_error(vm, "failed to find label while removing");
+        njs_internal_error(parser->vm, "failed to find label while removing");
         return NJS_ERROR;
     }
 
-    njs_rbtree_delete(&scope->labels, (njs_rbtree_part_t *) node);
-    njs_variable_node_free(vm, (njs_variable_node_t *) node);
+    njs_rbtree_delete(&parser->labels, (njs_rbtree_part_t *) node);
+    njs_mp_free(parser->vm->mem_pool, node);
 
     return NJS_OK;
 }
@@ -554,26 +536,14 @@ njs_variable_reference(njs_vm_t *vm, njs_parser_node_t *node)
 }
 
 
-njs_variable_t *
-njs_label_find(njs_vm_t *vm, njs_parser_scope_t *scope, uintptr_t atom_id)
+njs_bool_t
+njs_label_find(njs_parser_t *parser, uintptr_t atom_id)
 {
-    njs_rbtree_node_t    *node;
-    njs_variable_node_t  var_node;
+    njs_parser_label_t  label;
 
-    var_node.key = atom_id;
+    label.key = atom_id;
 
-    do {
-        node = njs_rbtree_find(&scope->labels, &var_node.node);
-
-        if (node != NULL) {
-            return ((njs_variable_node_t *) node)->variable;
-        }
-
-        scope = scope->parent;
-
-    } while (scope != NULL);
-
-    return NULL;
+    return njs_rbtree_find(&parser->labels, &label.node) != NULL;
 }
 
 

--- a/src/njs_variable.c
+++ b/src/njs_variable.c
@@ -514,14 +514,13 @@ njs_variable_reference(njs_vm_t *vm, njs_parser_node_t *node)
     if (ref->variable == NULL) {
         ref->variable = njs_variable_resolve(vm, node);
         if (njs_slow_path(ref->variable == NULL)) {
-            ref->not_defined = 1;
+            node->not_defined = 1;
 
             return NULL;
         }
     }
 
     closure = njs_variable_closure_test(node->scope, ref->variable->scope);
-    ref->scope = node->scope;
 
     ref_node.key = ref->atom_id;
 

--- a/src/njs_variable.h
+++ b/src/njs_variable.h
@@ -26,6 +26,7 @@ typedef struct {
     uint8_t               self;
     uint8_t               init;
     uint8_t               closure;
+    njs_scope_t           original_type:8;
 
     njs_parser_scope_t    *scope;
     njs_parser_scope_t    *original;
@@ -62,7 +63,8 @@ njs_variable_t *njs_variable_function_add(njs_parser_t *parser,
 njs_int_t njs_label_add(njs_parser_t *parser, uintptr_t atom_id);
 njs_bool_t njs_label_find(njs_parser_t *parser, uintptr_t atom_id);
 njs_int_t njs_label_remove(njs_parser_t *parser, uintptr_t atom_id);
-njs_variable_t *njs_variable_reference(njs_vm_t *vm, njs_parser_node_t *node);
+njs_variable_t *njs_variable_reference(njs_vm_t *vm, njs_mp_t *mem_pool,
+    njs_parser_node_t *node);
 njs_variable_t *njs_variable_scope_add(njs_parser_t *parser,
     njs_parser_scope_t *scope, njs_parser_scope_t *original,
     uintptr_t atom_id, njs_variable_type_t type, njs_index_t index);
@@ -70,11 +72,11 @@ njs_int_t njs_name_copy(njs_vm_t *vm, njs_str_t *dst, const njs_str_t *src);
 
 
 njs_inline njs_variable_node_t *
-njs_variable_node_alloc(njs_vm_t *vm, njs_variable_t *var, uintptr_t key)
+njs_variable_node_alloc(njs_mp_t *mem_pool, njs_variable_t *var, uintptr_t key)
 {
     njs_variable_node_t  *node;
 
-    node = njs_mp_zalloc(vm->mem_pool, sizeof(njs_variable_node_t));
+    node = njs_mp_zalloc(mem_pool, sizeof(njs_variable_node_t));
 
     if (njs_fast_path(node != NULL)) {
         node->key = key;

--- a/src/njs_variable.h
+++ b/src/njs_variable.h
@@ -43,11 +43,8 @@ typedef enum {
 
 
 typedef struct {
-    njs_reference_type_t  type;
     uintptr_t             atom_id;
     njs_variable_t        *variable;
-    njs_parser_scope_t    *scope;
-    njs_bool_t            not_defined;
 } njs_variable_reference_t;
 
 

--- a/src/njs_variable.h
+++ b/src/njs_variable.h
@@ -21,11 +21,11 @@ typedef struct {
     uintptr_t             atom_id;
 
     njs_variable_type_t   type:8;    /* 3 bits */
-    njs_bool_t            argument;
-    njs_bool_t            arguments_object;
-    njs_bool_t            self;
-    njs_bool_t            init;
-    njs_bool_t            closure;
+    uint8_t               argument;
+    uint8_t               arguments_object;
+    uint8_t               self;
+    uint8_t               init;
+    uint8_t               closure;
 
     njs_parser_scope_t    *scope;
     njs_parser_scope_t    *original;

--- a/src/njs_variable.h
+++ b/src/njs_variable.h
@@ -59,12 +59,9 @@ njs_variable_t *njs_variable_add(njs_parser_t *parser,
     njs_parser_scope_t *scope, uintptr_t atom_id, njs_variable_type_t type);
 njs_variable_t *njs_variable_function_add(njs_parser_t *parser,
     njs_parser_scope_t *scope, uintptr_t atom_id);
-njs_variable_t * njs_label_add(njs_vm_t *vm, njs_parser_scope_t *scope,
-    uintptr_t atom_id);
-njs_variable_t *njs_label_find(njs_vm_t *vm, njs_parser_scope_t *scope,
-    uintptr_t atom_id);
-njs_int_t njs_label_remove(njs_vm_t *vm, njs_parser_scope_t *scope,
-    uintptr_t atom_id);
+njs_int_t njs_label_add(njs_parser_t *parser, uintptr_t atom_id);
+njs_bool_t njs_label_find(njs_parser_t *parser, uintptr_t atom_id);
+njs_int_t njs_label_remove(njs_parser_t *parser, uintptr_t atom_id);
 njs_variable_t *njs_variable_reference(njs_vm_t *vm, njs_parser_node_t *node);
 njs_variable_t *njs_variable_scope_add(njs_parser_t *parser,
     njs_parser_scope_t *scope, njs_parser_scope_t *original,

--- a/src/njs_vm.c
+++ b/src/njs_vm.c
@@ -225,8 +225,8 @@ njs_vm_compile(njs_vm_t *vm, u_char **start, u_char *end)
 
     global_items = (vm->global_scope != NULL) ? vm->global_scope->items : 0;
 
-    ret = njs_parser_init(vm, &parser, vm->global_scope, &vm->options.file,
-                          *start, end);
+    ret = njs_parser_init(vm, &parser, vm->global_scope, 1,
+                          &vm->options.file, *start, end);
     if (njs_slow_path(ret != NJS_OK)) {
         return NJS_ERROR;
     }
@@ -341,7 +341,7 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
         return NULL;
     }
 
-    ret = njs_parser_init(vm, &parser, NULL, &module->name, *start, end);
+    ret = njs_parser_init(vm, &parser, NULL, 0, &module->name, *start, end);
     if (njs_slow_path(ret != NJS_OK)) {
         return NULL;
     }

--- a/src/njs_vm.c
+++ b/src/njs_vm.c
@@ -233,6 +233,7 @@ njs_vm_compile(njs_vm_t *vm, u_char **start, u_char *end)
 
     ret = njs_parser(vm, &parser);
     if (njs_slow_path(ret != NJS_OK)) {
+        njs_parser_destroy(&parser);
         return NJS_ERROR;
     }
 
@@ -240,10 +241,12 @@ njs_vm_compile(njs_vm_t *vm, u_char **start, u_char *end)
         NJS_CHB_MP_INIT(&chain, njs_vm_memory_pool(vm));
         ret = njs_parser_serialize_ast(parser.node, &chain);
         if (njs_slow_path(ret == NJS_ERROR)) {
+            njs_parser_destroy(&parser);
             return ret;
         }
 
         if (njs_slow_path(njs_chb_join(&chain, &ast) != NJS_OK)) {
+            njs_parser_destroy(&parser);
             return NJS_ERROR;
         }
 
@@ -259,6 +262,7 @@ njs_vm_compile(njs_vm_t *vm, u_char **start, u_char *end)
     ret = njs_generator_init(&generator, &vm->options.file, 0, 0);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
+        njs_parser_destroy(&parser);
         return NJS_ERROR;
     }
 
@@ -268,8 +272,11 @@ njs_vm_compile(njs_vm_t *vm, u_char **start, u_char *end)
             njs_internal_error(vm, "njs_generate_scope() failed");
         }
 
+        njs_parser_destroy(&parser);
         return NJS_ERROR;
     }
+
+    njs_parser_destroy(&parser);
 
     if (scope->items > global_items) {
         global = vm->levels[NJS_LEVEL_GLOBAL];
@@ -342,6 +349,7 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
 
     ret = njs_parser(vm, &parser);
     if (njs_slow_path(ret != NJS_OK)) {
+        njs_parser_destroy(&parser);
         return NULL;
     }
 
@@ -350,6 +358,7 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
     ret = njs_generator_init(&generator, &module->name, 0, 0);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
+        njs_parser_destroy(&parser);
         return NULL;
     }
 
@@ -357,12 +366,14 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
     if (njs_slow_path(code == NULL)) {
         njs_internal_error(vm, "njs_generate_scope() failed");
 
+        njs_parser_destroy(&parser);
         return NULL;
     }
 
     lambda = njs_mp_zalloc(vm->mem_pool, sizeof(njs_function_lambda_t));
     if (njs_fast_path(lambda == NULL)) {
         njs_memory_error(vm);
+        njs_parser_destroy(&parser);
         return NULL;
     }
 
@@ -372,6 +383,8 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
     lambda->nlocal = scope->items;
 
     module->function.u.lambda = lambda;
+
+    njs_parser_destroy(&parser);
 
     return module;
 }

--- a/src/njs_vm.c
+++ b/src/njs_vm.c
@@ -259,7 +259,8 @@ njs_vm_compile(njs_vm_t *vm, u_char **start, u_char *end)
     *start = parser.lexer->start;
     scope = parser.scope;
 
-    ret = njs_generator_init(&generator, &vm->options.file, 0, 0);
+    ret = njs_generator_init(&generator, parser.mem_pool, &vm->options.file,
+                             0, 0);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
         njs_parser_destroy(&parser);
@@ -355,7 +356,7 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
 
     *start = parser.lexer->start;
 
-    ret = njs_generator_init(&generator, &module->name, 0, 0);
+    ret = njs_generator_init(&generator, parser.mem_pool, &module->name, 0, 0);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
         njs_parser_destroy(&parser);

--- a/src/njs_vm.c
+++ b/src/njs_vm.c
@@ -241,11 +241,13 @@ njs_vm_compile(njs_vm_t *vm, u_char **start, u_char *end)
         NJS_CHB_MP_INIT(&chain, njs_vm_memory_pool(vm));
         ret = njs_parser_serialize_ast(parser.node, &chain);
         if (njs_slow_path(ret == NJS_ERROR)) {
+            njs_chb_destroy(&chain);
             njs_parser_destroy(&parser);
             return ret;
         }
 
         if (njs_slow_path(njs_chb_join(&chain, &ast) != NJS_OK)) {
+            njs_chb_destroy(&chain);
             njs_parser_destroy(&parser);
             return NJS_ERROR;
         }

--- a/src/njs_vm.c
+++ b/src/njs_vm.c
@@ -326,12 +326,17 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
     u_char *end)
 {
     njs_int_t              ret;
+    njs_uint_t             code_index;
     njs_mod_t              *module;
     njs_parser_t           parser;
     njs_vm_code_t          *code;
     njs_generator_t        generator;
     njs_parser_scope_t     *scope;
     njs_function_lambda_t  *lambda;
+
+    parser.mem_pool = NULL;
+    lambda = NULL;
+    code_index = (vm->codes != NULL) ? vm->codes->items : 0;
 
     module = njs_module_find(vm, name, 1);
     if (module != NULL) {
@@ -345,15 +350,14 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
 
     ret = njs_parser_init(vm, &parser, NULL, 0, &module->name, *start, end);
     if (njs_slow_path(ret != NJS_OK)) {
-        return NULL;
+        goto failed;
     }
 
     parser.module = 1;
 
     ret = njs_parser(vm, &parser);
     if (njs_slow_path(ret != NJS_OK)) {
-        njs_parser_destroy(&parser);
-        return NULL;
+        goto failed;
     }
 
     *start = parser.lexer->start;
@@ -361,23 +365,20 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
     ret = njs_generator_init(&generator, parser.mem_pool, &module->name, 0, 0);
     if (njs_slow_path(ret != NJS_OK)) {
         njs_internal_error(vm, "njs_generator_init() failed");
-        njs_parser_destroy(&parser);
-        return NULL;
+        goto failed;
     }
 
     code = njs_generate_scope(vm, &generator, parser.scope, &njs_entry_module);
     if (njs_slow_path(code == NULL)) {
         njs_internal_error(vm, "njs_generate_scope() failed");
 
-        njs_parser_destroy(&parser);
-        return NULL;
+        goto failed;
     }
 
     lambda = njs_mp_zalloc(vm->mem_pool, sizeof(njs_function_lambda_t));
     if (njs_fast_path(lambda == NULL)) {
         njs_memory_error(vm);
-        njs_parser_destroy(&parser);
-        return NULL;
+        goto failed;
     }
 
     scope = parser.scope;
@@ -390,6 +391,21 @@ njs_vm_compile_module(njs_vm_t *vm, njs_str_t *name, u_char **start,
     njs_parser_destroy(&parser);
 
     return module;
+
+failed:
+
+    if (parser.mem_pool != NULL) {
+        njs_parser_destroy(&parser);
+    }
+
+    if (lambda != NULL) {
+        njs_mp_free(vm->mem_pool, lambda);
+    }
+
+    njs_generator_cleanup(vm, code_index);
+    njs_module_remove(vm, module);
+
+    return NULL;
 }
 
 

--- a/src/njs_vmcode.c
+++ b/src/njs_vmcode.c
@@ -25,6 +25,8 @@ static njs_jump_off_t njs_vmcode_template_literal(njs_vm_t *vm,
 
 static njs_jump_off_t njs_vmcode_property_init(njs_vm_t *vm, njs_value_t *value,
     njs_value_t *key, njs_value_t *retval);
+static njs_jump_off_t njs_vmcode_array_init(njs_vm_t *vm, u_char *pc,
+    njs_value_t *array, njs_value_t *value);
 static njs_jump_off_t njs_vmcode_proto_init(njs_vm_t *vm, njs_value_t *value,
     njs_value_t *key, njs_value_t *retval);
 static njs_jump_off_t njs_vmcode_property_in(njs_vm_t *vm,
@@ -99,6 +101,7 @@ njs_vmcode_interpreter(njs_vm_t *vm, u_char *pc, njs_value_t *rval,
     njs_native_frame_t           *previous, *native;
     njs_property_next_t          *next;
     njs_vmcode_import_t          *import;
+    njs_vmcode_array_init_t      *array_init;
     njs_vmcode_generic_t         *vmcode;
     njs_vmcode_variable_t        *var;
     njs_vmcode_prop_get_t        *get;
@@ -150,6 +153,7 @@ njs_vmcode_interpreter(njs_vm_t *vm, u_char *pc, njs_value_t *rval,
         NJS_GOTO_ROW(NJS_VMCODE_IF_FALSE_JUMP),
         NJS_GOTO_ROW(NJS_VMCODE_IF_EQUAL_JUMP),
         NJS_GOTO_ROW(NJS_VMCODE_PROPERTY_INIT),
+        NJS_GOTO_ROW(NJS_VMCODE_ARRAY_INIT),
         NJS_GOTO_ROW(NJS_VMCODE_RETURN),
         NJS_GOTO_ROW(NJS_VMCODE_FUNCTION_FRAME),
         NJS_GOTO_ROW(NJS_VMCODE_METHOD_FRAME),
@@ -1468,6 +1472,21 @@ NEXT_LBL;
 
         BREAK;
 
+    CASE (NJS_VMCODE_ARRAY_INIT):
+        njs_vmcode_debug_opcode();
+
+        array_init = (njs_vmcode_array_init_t *) pc;
+
+        njs_vmcode_operand(vm, array_init->array, value1);
+        njs_vmcode_operand(vm, array_init->value, value2);
+
+        ret = njs_vmcode_array_init(vm, pc, value1, value2);
+        if (njs_slow_path(ret < 0 && ret >= NJS_PREEMPT)) {
+            goto error;
+        }
+
+        BREAK;
+
     CASE (NJS_VMCODE_RETURN):
         njs_vmcode_debug_opcode();
 
@@ -1913,7 +1932,7 @@ njs_vmcode_array(njs_vm_t *vm, u_char *pc, njs_value_t *retval)
 
     code = (njs_vmcode_array_t *) pc;
 
-    array = njs_array_alloc(vm, 0, code->length, NJS_ARRAY_SPARE);
+    array = njs_array_alloc(vm, code->flat, code->length, NJS_ARRAY_SPARE);
 
     if (njs_fast_path(array != NULL)) {
 
@@ -2052,63 +2071,66 @@ njs_vmcode_template_literal(njs_vm_t *vm, njs_value_t *retval)
 
 
 static njs_jump_off_t
-njs_vmcode_property_init(njs_vm_t *vm, njs_value_t *value, njs_value_t *key,
+njs_vmcode_array_init(njs_vm_t *vm, u_char *pc, njs_value_t *value,
     njs_value_t *init)
 {
-    double               num;
-    uint32_t             index, size;
-    njs_int_t            ret;
-    njs_array_t          *array;
-    njs_value_t          *val, name;
-    njs_object_prop_t    *prop;
-    njs_flathsh_query_t  fhq;
+    uint32_t                 index, size;
+    njs_array_t              *array;
+    njs_value_t              *entry;
+    njs_object_prop_t        *prop;
+    njs_vmcode_array_init_t  *code;
 
-    switch (value->type) {
-    case NJS_ARRAY:
-        num = njs_key_to_index(key);
-        if (njs_slow_path(!njs_key_is_integer_index(num, key))) {
-            njs_internal_error(vm,
-                               "invalid index while property initialization");
-            return NJS_ERROR;
-        }
+    code = (njs_vmcode_array_init_t *) pc;
+    index = code->index;
 
-        index = (uint32_t) num;
-        array = value->data.u.array;
+    if (njs_slow_path(!njs_is_array(value))) {
+        njs_internal_error(vm, "array initialization target is not an array");
+        return NJS_ERROR;
+    }
 
-        if (njs_slow_path(!array->object.fast_array)) {
-            prop = njs_object_property_add(vm, value, njs_number_atom(index),
-                                           0);
-            if (njs_slow_path(prop == NULL)) {
-                return NJS_ERROR;
-            }
+    array = njs_array(value);
 
-            njs_value_assign(njs_prop_value(prop), init);
-            break;
-        }
+    if (njs_fast_path(array->object.fast_array)) {
+        njs_assert(index < array->size);
 
         if (index >= array->length) {
+            entry = &array->start[array->length];
             size = index - array->length;
 
-            ret = njs_array_expand(vm, array, 0, size + 1);
-            if (njs_slow_path(ret != NJS_OK)) {
-                return ret;
-            }
-
-            val = &array->start[array->length];
-
             while (size != 0) {
-                njs_set_invalid(val);
-                val++;
+                njs_set_invalid(entry);
+                entry++;
                 size--;
             }
 
             array->length = index + 1;
         }
 
-        array->start[index] = *init;
+        njs_value_assign(&array->start[index], init);
 
-        break;
+    } else {
+        prop = njs_object_property_add(vm, value, njs_number_atom(index), 0);
+        if (njs_slow_path(prop == NULL)) {
+            return NJS_ERROR;
+        }
 
+        njs_value_assign(njs_prop_value(prop), init);
+    }
+
+    return sizeof(njs_vmcode_array_init_t);
+}
+
+
+static njs_jump_off_t
+njs_vmcode_property_init(njs_vm_t *vm, njs_value_t *value, njs_value_t *key,
+    njs_value_t *init)
+{
+    njs_int_t            ret;
+    njs_value_t          name;
+    njs_object_prop_t    *prop;
+    njs_flathsh_query_t  fhq;
+
+    switch (value->type) {
     case NJS_OBJECT:
         if (key->type == NJS_STRING) {
             if (key->atom_id == NJS_ATOM_STRING_unknown) {

--- a/src/njs_vmcode.c
+++ b/src/njs_vmcode.c
@@ -2075,6 +2075,17 @@ njs_vmcode_property_init(njs_vm_t *vm, njs_value_t *value, njs_value_t *key,
         index = (uint32_t) num;
         array = value->data.u.array;
 
+        if (njs_slow_path(!array->object.fast_array)) {
+            prop = njs_object_property_add(vm, value, njs_number_atom(index),
+                                           0);
+            if (njs_slow_path(prop == NULL)) {
+                return NJS_ERROR;
+            }
+
+            njs_value_assign(njs_prop_value(prop), init);
+            break;
+        }
+
         if (index >= array->length) {
             size = index - array->length;
 

--- a/src/njs_vmcode.h
+++ b/src/njs_vmcode.h
@@ -37,6 +37,7 @@ enum {
     NJS_VMCODE_IF_FALSE_JUMP,
     NJS_VMCODE_IF_EQUAL_JUMP,
     NJS_VMCODE_PROPERTY_INIT,
+    NJS_VMCODE_ARRAY_INIT,
     NJS_VMCODE_RETURN,
     NJS_VMCODE_FUNCTION_FRAME,
     NJS_VMCODE_METHOD_FRAME,
@@ -175,6 +176,7 @@ typedef struct {
     njs_index_t                retval;
     uintptr_t                  length;
     uint8_t                    ctor;       /* 1 bit  */
+    uint8_t                    flat;       /* 1 bit  */
 } njs_vmcode_array_t;
 
 
@@ -249,6 +251,14 @@ typedef struct {
     njs_index_t                object;
     njs_index_t                property;
 } njs_vmcode_prop_set_t;
+
+
+typedef struct {
+    njs_vmcode_t               code;
+    uint32_t                   index;
+    njs_index_t                value;
+    njs_index_t                array;
+} njs_vmcode_array_init_t;
 
 
 typedef struct {

--- a/src/test/njs_benchmark.c
+++ b/src/test/njs_benchmark.c
@@ -119,6 +119,11 @@ njs_benchmark_test(njs_vm_t *parent, njs_opts_t *opts, njs_value_t *report,
     options.backtrace = 1;
     options.addons = njs_benchmark_addon_external_modules;
 
+    if (strncmp(test->name, "compile ", njs_length("compile ")) == 0) {
+        options.max_stack_size = 64 * 1024 * 1024;
+        options.unsafe = 1;
+    }
+
     vm = NULL;
     nvm = NULL;
     ret = NJS_ERROR;
@@ -285,6 +290,45 @@ static njs_benchmark_test_t  njs_test[] =
               "sum"),
       njs_str("4"),
       100000 },
+
+    { "compile array references 1M",
+      njs_str("Function('var x; return [' + 'x,'.repeat(999999) + 'x]'); 1"),
+      njs_str("1"),
+      1 },
+
+    { "compile sequential block declarations 100K",
+      njs_str("Function('{let x=0;}'.repeat(100000)); 1"),
+      njs_str("1"),
+      1 },
+
+    { "compile sequential labels 100K",
+      njs_str("Function('a:;'.repeat(100000)); 1"),
+      njs_str("1"),
+      1 },
+
+    { "compile unique declarations 100K",
+      njs_str("Function(Array(100000).fill(0)"
+              ".map((v, i) => 'let x' + i + '=0;').join('')); 1"),
+      njs_str("1"),
+      1 },
+
+    { "compile referenced declarations 100K",
+      njs_str("Function(Array(100000).fill(0)"
+              ".map((v, i) => 'let x' + i + '=0;x' + i + ';').join('')); 1"),
+      njs_str("1"),
+      1 },
+
+    { "compile closures 20K",
+      njs_str("Function('void function(){let x=1;return ()=>x;};'"
+              ".repeat(20000)); 1"),
+      njs_str("1"),
+      1 },
+
+    { "compile nested labels 10K",
+      njs_str("Function(Array(10000).fill(0)"
+              ".map((v, i) => 'a' + i + ':').join('') + ';'); 1"),
+      njs_str("1"),
+      1 },
 
     { "string create 'abcdefABCDEF'",
       njs_str("benchmark.string('create', 'abcdef', 1000000)"),

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -1158,6 +1158,22 @@ static njs_unit_test_t  njs_test[] =
     { njs_str("var a = 1; function f(x) { a = x; return 2 }; a += f(5)"),
       njs_str("3") },
 
+    { njs_str("var src = 'var a=1;return a+' + '('.repeat(256)"
+              "+ '0+'.repeat(256) + '(a=2)' + ')'.repeat(256);"
+              "(new Function(src))()"),
+      njs_str("3") },
+
+    { njs_str("var src = 'var a=1;a+=' + '('.repeat(256)"
+              "+ '0+'.repeat(256) + '(a=2)' + ')'.repeat(256) + ';return a';"
+              "(new Function(src))()"),
+      njs_str("3") },
+
+    { njs_str("var src = 'var i=0,a=[];a[i]=' + '['.repeat(256)"
+              "+ '(i=1)' + ']'.repeat(256)"
+              "+ ';return a[0] !== undefined && a[1] === undefined';"
+              "(new Function(src))()"),
+      njs_str("true") },
+
     { njs_str("var x; x in (x = 1, [1, 2, 3])"),
       njs_str("false") },
 

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -15395,6 +15395,11 @@ static njs_unit_test_t  njs_test[] =
               "sum(2, 4);"),
       njs_str("6") },
 
+    { njs_str("(new Function('a',"
+              " 'return function(b) { return function(c) {"
+              " return a + b + c; }; };'))(1)(2)(3)"),
+      njs_str("6") },
+
     { njs_str("var sum = new Function('a, b', 'c', 'return a + b + c');"
               "sum(2, 4, 4);"),
       njs_str("10") },

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -5001,6 +5001,11 @@ static njs_unit_test_t  njs_test[] =
     { njs_str("[1,2].length"),
       njs_str("2") },
 
+    { njs_str("var src = 'return [' + '1,'.repeat(32760) + '1]';"
+              "var a = Function(src)();"
+              "[a.length, a[0], a[32760], Object.keys(a).length]"),
+      njs_str("32761,1,1,32761") },
+
     { njs_str("var a = [1,2]; a.length"),
       njs_str("2") },
 

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -3973,6 +3973,18 @@ static njs_unit_test_t  njs_test[] =
     { njs_str("a : var n = 0; b :++n"),
       njs_str("1") },
 
+    { njs_str("var r = 0; outer: for (;;) { inner: break outer; r++ } r"),
+      njs_str("0") },
+
+    { njs_str("var r = 0; outer: for (; r < 3; r++) {"
+                  "inner: continue outer } r"),
+      njs_str("3") },
+
+    { njs_str("var x = 0, f = () => ++x;"
+                  "a: x = 1; b: x++; c: f(); d: [1,2].length;"
+                  "e: 's'; g: typeof x; x"),
+      njs_str("3") },
+
     { njs_str("a:{a:1}"),
       njs_str("SyntaxError: Label \"a\" has already been declared") },
 

--- a/src/test/njs_unit_test.c
+++ b/src/test/njs_unit_test.c
@@ -4902,6 +4902,25 @@ static njs_unit_test_t  njs_test[] =
     { njs_str("var n = 1, a = [ n += 1 ]; a"),
       njs_str("2") },
 
+    { njs_str("var a = 1; a = [a, 2]"),
+      njs_str("1,2") },
+
+    { njs_str("var a; a = [(a = 1, 2)]"),
+      njs_str("2") },
+
+    { njs_str("var i = 0; [i++, i++, i++]"),
+      njs_str("0,1,2") },
+
+    { njs_str("var a = [, 1, , 2, ,];"
+              "[a.length, Object.keys(a).length, 0 in a, 4 in a]"),
+      njs_str("5,2,false,false") },
+
+    { njs_str("njs.dump([1, [2, [3, 4]], 5])"),
+      njs_str("[1,[2,[3,4]],5]") },
+
+    { njs_str("var a = 1; a += [(a = 5, 1)][0]; a"),
+      njs_str("2") },
+
     { njs_str("var a = [ 1, 2; 3 ]; a[0] + a[1] + a[2]"),
       njs_str("SyntaxError: Unexpected token \";\"") },
 


### PR DESCRIPTION
This series substantially reduces memory consumption and compilation time in the built-in njs engine. It introduces a compact representation for array literals, reduces the size of common parser structures, and separates temporary parser and generator state from data that must remain alive after compilation.

Previously, each element in an array literal was lowered through the generic object-property path. A single element such as `x` in `[x, x, ...]` required six parser nodes, several generator continuation entries, an interned numeric property key, and a generic property-initialization instruction. At one million elements, compilation retained more than 1 GB in the VM memory pool.

Array elements are now represented by compact `{ value, index }` records and generated sequentially using a dedicated immediate-index initialization instruction. This removes five parser nodes per element, avoids numeric index constants, keeps generator continuation depth constant, and reduces generated bytecode from approximately 32 MB to 24 MB.

The series also fixes an existing correctness issue: array literals larger than 32,760 elements previously had the expected `length` but did not contain their initialized values after switching to the slow-array representation.

## Structure Changes

| Structure | Before | After | Pool allocation class |
| --- | ---: | ---: | ---: |
| `njs_parser_node_t` | 104 B | 64 B | 128 B to 64 B |
| `njs_variable_reference_t` | 40 B | 16 B | embedded |
| `njs_parser_scope_t` | 136 B | 104 B | 256 B to 128 B |
| `njs_variable_t` | 96 B | 56 B | 128 B to 64 B |

Active labels are stored in a parser-wide indexed set instead of allocating complete variables and wrappers in every scope. Statement labels use atom identifiers instead of storing an `njs_str_t` in every parser node.

## Compilation Lifetime

Each parser invocation now owns a temporary memory pool. It contains parser nodes, compact array-item storage, parser continuations, lexer preread tokens, active labels, generator stack entries and copied contexts, generator blocks and jump patches, traversal and index-cache scratch, non-global scopes, local variables and variable-tree nodes, reference maps, declaration arrays, and temporary closure-index builders.

The pool is destroyed after bytecode generation and on parser or generator failure in the main script, module, and runtime `Function` compilation paths.

The global scope and global variables, atoms and parser-created strings, function lambdas and regexp patterns, generated bytecode and line maps, runtime constants, module records, and finalized closure-index arrays remain persistent because runtime state references them.

Closure indexes are accumulated in temporary arrays and copied into exact-sized VM-owned storage before the compilation pool is destroyed. Persistent global variables retain declaration-origin type information without retaining pointers to released block scopes.

The series also adds local failure cleanup for AST serialization and provisional module compilation. Failed module compilation removes the provisional module and releases generated code records, line maps, and code buffers created after the compilation checkpoint. Top-level global compilation is intentionally not made transactional; callers should discard the VM after a failed top-level compilation.

## Results

Median fresh-process measurements on AArch64:

| Workload | Baseline RSS | Current RSS | Reduction | Baseline time | Current time |
| --- | ---: | ---: | ---: | ---: | ---: |
| Array references 1M | 1,097,232 KiB | 156,180 KiB | 85.8% | 3.96 s | 0.57 s |
| Declarations 100K | 146,168 KiB | 104,072 KiB | 28.8% | 0.41 s | 0.25 s |
| Labels 100K | 76,064 KiB | 47,884 KiB | 37.1% | 0.10 s | 0.06 s |
| `test/buffer.t.js` | 10,740 KiB | 9,400 KiB | 12.5% | <0.01 s | <0.01 s |

Retained VM memory after compilation:

| Workload | Baseline | Current | Reduction |
| --- | ---: | ---: | ---: |
| Array references 1M | 1,043.4 MB | 34.2 MB | 96.7% |
| Declarations 100K | 127.7 MB | 57.3 MB | 55.1% |
| Labels 100K | 47.7 MB | 7.7 MB | 83.9% |
| `test/buffer.t.js` | 2.77 MB | 0.59 MB | 78.8% |

The semantic-state lifetime changes provide additional retained-memory reductions relative to the initial node-only temporary pool:

| Workload | Node-only pool | Final | Additional reduction |
| --- | ---: | ---: | ---: |
| 100K sequential block declarations | 39.1 MB | 7.1 MB | 81.9% |
| 20K arrow closures | 17.2 MB | 8.6 MB | 50.2% |
| 20K declared functions with closures | 37.0 MB | 17.5 MB | 52.6% |

Peak RSS changes little during the semantic-state stage because scopes, variables, references, and AST nodes are all needed until generation completes. The primary benefit is reducing memory retained by long-lived VMs.

## NGINX Master and Workers

A separate benchmark loaded a 6.89 MB module containing a one-million-element numeric array through `js_import`, using the njs engine and four workers.

| Metric | Baseline | Current | Reduction |
| --- | ---: | ---: | ---: |
| Master RSS before requests | 1,116.7 MiB | 172.9 MiB | 84.5% |
| Worker RSS before requests | 1,117.3 MiB | 173.7 MiB | 84.5% |
| Process-group PSS before requests | 1,118.5 MiB | 175.0 MiB | 84.4% |
| Process-group PSS after warmup | 1,248.3 MiB | 399.3 MiB | 68.0% |

The imported compilation state is initially almost entirely shared through copy-on-write. After all workers execute the module, each worker materializes private runtime array state, but the process group remains approximately 849 MiB smaller than the baseline. Memory remained stable after 100, 1,000, and 10,000 requests and after a subsequent idle period.

NGINX startup time, including configuration loading, import compilation, daemon startup, and worker creation, improved from approximately 4.43 seconds to 0.71 seconds.

## Stress Benchmarks

The benchmark suite now includes focused generated workloads for one million array references, 100,000 sequential block declarations, 100,000 sequential labels, 100,000 unique declarations, 100,000 referenced declarations, 20,000 closures, and 10,000 nested labels.

These are scaling stress tests rather than isolated parser timings. Their measured interval includes source construction, runtime `Function` compilation, VM cloning, and cleanup.

## Validation

- Value-preservation analysis is limited to 128 recursive levels. Deeper expressions conservatively request a temporary copy instead of risking native stack exhaustion.
- Disassembly comparisons against the parent commit show identical opcode histograms and `MOVE` counts for `bench4.js`, `raytrace.js`, `deltablue.js`, `navier-stokes.js`, `splay.js`, `richards.js`, and `crypto.js`. The depth guard therefore adds no bytecode overhead for these ordinary workloads.